### PR TITLE
Fix editar no media id disponible

### DIFF
--- a/src/components/EditTemplateForm.jsx
+++ b/src/components/EditTemplateForm.jsx
@@ -396,6 +396,16 @@ const EditTemplateForm = () => {
 
     }
 
+    if (!isValid) {
+    Swal.fire({
+      title: 'Error',
+      text: 'Campos incompletos.',
+      icon: 'error',
+      confirmButtonText: 'Cerrar',
+      confirmButtonColor: '#00c3ff'
+    });
+  }
+
 
     return isValid; // Retornar el valor final de isValid
   };
@@ -406,13 +416,7 @@ const EditTemplateForm = () => {
 
     const isValid = validateFields();
     if (!isValid) {
-      Swal.fire({
-        title: 'Error',
-        text: 'Campos incompletos.',
-        icon: 'error',
-        confirmButtonText: 'Cerrar',
-        confirmButtonColor: '#00c3ff'
-      });
+      //Swal.fire({title: 'Error', text: 'Campos incompletos.', icon: 'error', confirmButtonText: 'Cerrar', confirmButtonColor: '#00c3ff'});
       setLoading(false);
       return;
     }

--- a/src/components/EditTemplateForm.jsx
+++ b/src/components/EditTemplateForm.jsx
@@ -238,6 +238,16 @@ const EditTemplateForm = () => {
   const validateFields = () => {
     let isValid = true;
 
+    if (templateType === "IMAGE" && !mediaId) {
+    Swal.fire({
+      title: 'Imagen requerida',
+      text: 'Debes cargar una imagen para este tipo de plantilla.',
+      icon: 'warning',
+      confirmButtonText: 'Entendido',
+      confirmButtonColor: '#00c3ff'
+    });
+    return false;
+  }
 
 
     if (!templateName || templateName.trim() === "") {


### PR DESCRIPTION
Se modifica edición de plantilla, al no recibir un mediaId valido porque la plantilla fue creada en el portal de administración gupshup y no por medio del administrador de plantillas TalkMe (api) se solicita al usuario que vuelva a cargar la imagen.