### PR TITLE
Modificación de sidebar y navegacion

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import { jwtDecode } from 'jwt-decode';
 import AppRoutes from './routes';
 import LoadingSpinner from './utils/LoadingSpinner';
 import SessionManager from './hooks/SessionManager';
+import { RouteProvider } from './contexts/RouteContext';
 
 function App() {
   const location = useLocation();
@@ -20,58 +21,58 @@ function App() {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-  const checkToken = async () => {
-    const searchParams = new URLSearchParams(location.search);
-    const urlToken = searchParams.get('token');
-    const storedToken = sessionStorage.getItem('authToken');
-    
-    // Si no hay token en absoluto
-    if (!urlToken && !storedToken) {
-      navigate('/login-required');
-      return;
-    }
+    const checkToken = async () => {
+      const searchParams = new URLSearchParams(location.search);
+      const urlToken = searchParams.get('token');
+      const storedToken = sessionStorage.getItem('authToken');
 
-    try {
-      // Usar token de URL si existe, sino el almacenado
-      const tokenToValidate = urlToken || storedToken;
-      const decoded = jwtDecode(tokenToValidate);
-      const currentTime = Date.now() / 1000;
-
-      // Token expirado
-      if (decoded.exp < currentTime) {
-        cleanStorageAndRedirect();
+      // Si no hay token en absoluto
+      if (!urlToken && !storedToken) {
+        navigate('/login-required');
         return;
       }
 
-      // Si hay nuevo token de URL, actualizar storage
-      if (urlToken && urlToken !== storedToken) {
-        sessionStorage.setItem('authToken', urlToken);
-        
-        const remainingTimeInSeconds = decoded.exp - currentTime;
-        const remainingMinutesOnly = Math.floor(remainingTimeInSeconds / 60);
-        
-        sessionStorage.setItem('initialRemainingMinutes', remainingMinutesOnly.toString());
-        
-        // Limpiar token de la URL
-        window.history.replaceState({}, document.title, window.location.pathname);
+      try {
+        // Usar token de URL si existe, sino el almacenado
+        const tokenToValidate = urlToken || storedToken;
+        const decoded = jwtDecode(tokenToValidate);
+        const currentTime = Date.now() / 1000;
+
+        // Token expirado
+        if (decoded.exp < currentTime) {
+          cleanStorageAndRedirect();
+          return;
+        }
+
+        // Si hay nuevo token de URL, actualizar storage
+        if (urlToken && urlToken !== storedToken) {
+          sessionStorage.setItem('authToken', urlToken);
+
+          const remainingTimeInSeconds = decoded.exp - currentTime;
+          const remainingMinutesOnly = Math.floor(remainingTimeInSeconds / 60);
+
+          sessionStorage.setItem('initialRemainingMinutes', remainingMinutesOnly.toString());
+
+          // Limpiar token de la URL
+          window.history.replaceState({}, document.title, window.location.pathname);
+        }
+
+        setIsLoading(false);
+
+      } catch (error) {
+        console.error('Error procesando token:', error);
+        cleanStorageAndRedirect();
       }
+    };
 
-      setIsLoading(false);
-      
-    } catch (error) {
-      console.error('Error procesando token:', error);
-      cleanStorageAndRedirect();
-    }
-  };
+    const cleanStorageAndRedirect = () => {
+      sessionStorage.removeItem('authToken');
+      sessionStorage.removeItem('initialRemainingMinutes');
+      navigate('/login-required');
+    };
 
-  const cleanStorageAndRedirect = () => {
-    sessionStorage.removeItem('authToken');
-    sessionStorage.removeItem('initialRemainingMinutes');
-    navigate('/login-required');
-  };
-
-  checkToken();
-}, [location.search, navigate]);
+    checkToken();
+  }, [location.search, navigate]);
 
 
   const theme = useMemo(() =>
@@ -99,10 +100,12 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <SessionManager />
-      <Box sx={{ display: "flex" }}>
-        <AppRoutes />
-      </Box>
+      <RouteProvider>
+        <SessionManager />
+        <Box sx={{ display: "flex" }}>
+          <AppRoutes />
+        </Box>
+      </RouteProvider>
     </ThemeProvider>
   );
 }

--- a/src/components/ListBase.jsx
+++ b/src/components/ListBase.jsx
@@ -1,0 +1,268 @@
+// components/ListBase.jsx
+import React, { useState } from 'react';
+import {
+    Box,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    Paper,
+    IconButton,
+    Tooltip,
+    Chip,
+    Typography,
+    Menu,
+    MenuItem,
+    ListItemIcon,
+    ListItemText,
+    Fade,
+    LinearProgress
+} from '@mui/material';
+import { motion } from 'framer-motion';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import LinkIcon from '@mui/icons-material/Link';
+import PhoneIcon from '@mui/icons-material/Phone';
+import ReplyIcon from '@mui/icons-material/Reply';
+import ProductionQuantityLimitsIcon from '@mui/icons-material/ProductionQuantityLimits';
+import AccountTreeIcon from '@mui/icons-material/AccountTree';
+
+import FechaModificacion from '../utils/FechaModificacion';
+
+const ListBase = ({
+    templates = [],
+    handleEdit,
+    handleDeleteClick,
+    showReasonAlert,
+    parseTemplateContent,
+    getStatusColor,
+    getStatusDotColor,
+    getStatusTextColor
+}) => {
+    const [anchorEl, setAnchorEl] = useState(null);
+    const [selectedTemplate, setSelectedTemplate] = useState(null);
+
+    const handleClickMenu = (event, template) => {
+        event.stopPropagation();
+        setAnchorEl(event.currentTarget);
+        setSelectedTemplate(template);
+    };
+
+    const handleCloseMenu = () => {
+        setAnchorEl(null);
+        setSelectedTemplate(null);
+    };
+
+    const getButtonsFromTemplate = (template) => {
+        try {
+            const containerMeta = JSON.parse(template.gupshup.containerMeta);
+            return containerMeta.buttons || [];
+        } catch {
+            return [];
+        }
+    };
+
+    const getButtonIcon = (type) => {
+        const icons = {
+            QUICK_REPLY: <ReplyIcon fontSize="small" />,
+            URL: <LinkIcon fontSize="small" />,
+            PHONE_NUMBER: <PhoneIcon fontSize="small" />,
+            CATALOG: <ProductionQuantityLimitsIcon fontSize="small" />,
+            FLOW: <AccountTreeIcon fontSize="small" />
+        };
+        return icons[type] || null;
+    };
+
+    if (!templates.length) {
+        return (
+            <Box sx={{ textAlign: 'center', py: 8, color: 'text.secondary' }}>
+                <Typography>No hay plantillas para mostrar</Typography>
+            </Box>
+        );
+    }
+
+    return (
+        <>
+            <TableContainer
+                component={motion.div}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3 }}
+            >
+                <Paper sx={{ width: '100%', overflow: 'hidden', borderRadius: 2 }}>
+                    <Table stickyHeader size="medium">
+                        <TableHead>
+                            <TableRow sx={{ bgcolor: 'background.default' }}>
+                                <TableCell sx={{ fontWeight: 600, minWidth: 200 }}>Nombre</TableCell>
+                                <TableCell sx={{ fontWeight: 600, minWidth: 100 }}>Estado</TableCell>
+                                <TableCell sx={{ fontWeight: 600, minWidth: 120 }}>Categoría</TableCell>
+                                <TableCell sx={{ fontWeight: 600, minWidth: 100 }}>Tipo</TableCell>
+                                <TableCell sx={{ fontWeight: 600, minWidth: 150 }}>Botones</TableCell>
+                                <TableCell sx={{ fontWeight: 600, minWidth: 120 }}>Modificado</TableCell>
+                                <TableCell align="right" sx={{ fontWeight: 600, minWidth: 80 }}>Acciones</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {templates.map((template, index) => (
+                                <motion.tr
+                                    key={template.gupshup.id || index}
+                                    initial={{ opacity: 0, x: -20 }}
+                                    animate={{ opacity: 1, x: 0 }}
+                                    transition={{ delay: index * 0.05 }}
+                                    style={{ textDecoration: 'none' }}
+                                    sx={{
+                                        '&:hover': { bgcolor: 'action.hover', cursor: 'pointer' },
+                                        transition: 'background-color 0.2s ease'
+                                    }}
+                                >
+                                    {/* Nombre */}
+                                    <TableCell>
+                                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                            <Typography
+                                                variant="subtitle2"
+                                                fontWeight={500}
+                                                sx={{
+                                                    maxWidth: 180,
+                                                    overflow: 'hidden',
+                                                    textOverflow: 'ellipsis',
+                                                    whiteSpace: 'nowrap'
+                                                }}
+                                            >
+                                                {template.gupshup.elementName}
+                                            </Typography>
+                                            {template.gupshup.reason && (
+                                                <Tooltip title="Ver razón de rechazo">
+                                                    <IconButton
+                                                        size="small"
+                                                        onClick={(e) => {
+                                                            e.stopPropagation();
+                                                            showReasonAlert(template.gupshup.reason);
+                                                        }}
+                                                        sx={{ color: 'error.main' }}
+                                                    >
+                                                        <VisibilityIcon fontSize="small" />
+                                                    </IconButton>
+                                                </Tooltip>
+                                            )}
+                                        </Box>
+                                    </TableCell>
+
+                                    {/* Estado */}
+                                    <TableCell>
+                                        <Chip
+                                            size="small"
+                                            label={template.gupshup.status}
+                                            sx={{
+                                                bgcolor: getStatusColor(template.gupshup.status),
+                                                color: getStatusTextColor(template.gupshup.status),
+                                                fontWeight: 500,
+                                                '& .MuiChip-label': { px: 1 },
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                gap: 0.5
+                                            }}
+                                            icon={
+                                                <Box
+                                                    component="span"
+                                                    sx={{
+                                                        width: 6,
+                                                        height: 6,
+                                                        borderRadius: '50%',
+                                                        backgroundColor: getStatusDotColor(template.gupshup.status)
+                                                    }}
+                                                />
+                                            }
+                                        />
+                                    </TableCell>
+
+                                    {/* Categoría */}
+                                    <TableCell>
+                                        <Typography variant="body2">{template.gupshup.category}</Typography>
+                                    </TableCell>
+
+                                    {/* Tipo */}
+                                    <TableCell>
+                                        <Typography variant="body2">{template.gupshup.templateType}</Typography>
+                                    </TableCell>
+
+                                    {/* Botones */}
+                                    <TableCell>
+                                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                                            {getButtonsFromTemplate(template).slice(0, 3).map((btn, i) => (
+                                                <Chip
+                                                    key={i}
+                                                    size="small"
+                                                    label={btn.text}
+                                                    variant="outlined"
+                                                    sx={{ fontSize: 11, height: 24 }}
+                                                    icon={getButtonIcon(btn.type)}
+                                                />
+                                            ))}
+                                            {getButtonsFromTemplate(template).length > 3 && (
+                                                <Chip
+                                                    size="small"
+                                                    label={`+${getButtonsFromTemplate(template).length - 3}`}
+                                                    variant="outlined"
+                                                    sx={{ fontSize: 11, height: 24 }}
+                                                />
+                                            )}
+                                        </Box>
+                                    </TableCell>
+
+                                    {/* Fecha de modificación */}
+                                    <TableCell>
+                                        <Typography variant="caption" color="text.secondary">
+                                            <FechaModificacion timestamp={template.gupshup.modifiedOn} />
+                                        </Typography>
+                                    </TableCell>
+
+                                    {/* Acciones */}
+                                    <TableCell align="right">
+                                        <IconButton
+                                            size="small"
+                                            onClick={(e) => handleClickMenu(e, template)}
+                                            sx={{ color: 'text.secondary', '&:hover': { color: 'primary.main' } }}
+                                        >
+                                            <MoreVertIcon fontSize="small" />
+                                        </IconButton>
+                                    </TableCell>
+                                </motion.tr>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </Paper>
+            </TableContainer>
+
+            {/* Menú contextual */}
+            <Menu
+                anchorEl={anchorEl}
+                open={Boolean(anchorEl)}
+                onClose={handleCloseMenu}
+                TransitionComponent={Fade}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+            >
+                <MenuItem
+                    onClick={() => { handleEdit(selectedTemplate); handleCloseMenu(); }}
+                    sx={{ gap: 1 }}
+                >
+                    <ListItemIcon><EditIcon fontSize="small" /></ListItemIcon>
+                    <ListItemText>Editar</ListItemText>
+                </MenuItem>
+                <MenuItem
+                    onClick={() => { handleDeleteClick(selectedTemplate); handleCloseMenu(); }}
+                    sx={{ gap: 1, color: 'error.main' }}
+                >
+                    <ListItemIcon><DeleteIcon fontSize="small" /></ListItemIcon>
+                    <ListItemText>Eliminar</ListItemText>
+                </MenuItem>
+            </Menu>
+        </>
+    );
+};
+
+export default ListBase;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -6,6 +6,8 @@ import { DashboardLayout } from '@toolpad/core/DashboardLayout';
 import { useTheme } from '@mui/material/styles';
 import { IconButton, Tooltip } from '@mui/material';
 import Swal from 'sweetalert2';
+import { Suspense } from 'react';
+import LoadingSpinner from '../utils/LoadingSpinner';
 
 // Iconos
 import DashboardIcon from '@mui/icons-material/Dashboard';
@@ -16,8 +18,6 @@ import SendIcon from '@mui/icons-material/Send';
 import SmsFailedIcon from '@mui/icons-material/SmsFailed';
 import ThumbDownIcon from '@mui/icons-material/ThumbDown';
 import WhatsAppIcon from '@mui/icons-material/WhatsApp';
-import EmailIcon from '@mui/icons-material/Email';
-import ForumIcon from '@mui/icons-material/Forum';
 import AutoAwesomeMosaicIcon from '@mui/icons-material/AutoAwesomeMosaic';
 import ViewCarouselIcon from '@mui/icons-material/ViewCarousel';
 import LogoutIcon from '@mui/icons-material/Logout';
@@ -116,31 +116,31 @@ export default function Sidebar(props) {
   const location = useLocation();
   const navigate = useNavigate();
 
-const handleLogout = () => {
-  Swal.fire({
-    title: 'Cerrar sesión',
-    text: "¿Estás seguro que deseas salir?",
-    icon: 'question',
-    showCancelButton: true,
-    confirmButtonColor: '#00c3ff',
-    cancelButtonColor: '#d33',
-    confirmButtonText: 'Sí, cerrar sesión',
-    cancelButtonText: 'Cancelar'
-  }).then((result) => {
-    if (result.isConfirmed) {
-     
-      Swal.fire({
-        title: '¡Sesión cerrada!',
-        text: 'Has cerrado sesión exitosamente',
-        icon: 'success',
-        timer: 750,
-        showConfirmButton: false
-      }).then(() => {
-        navigate('/session-closed');
-      });
-    }
-  });
-};
+  const handleLogout = () => {
+    Swal.fire({
+      title: 'Cerrar sesión',
+      text: "¿Estás seguro que deseas salir?",
+      icon: 'question',
+      showCancelButton: true,
+      confirmButtonColor: '#00c3ff',
+      cancelButtonColor: '#d33',
+      confirmButtonText: 'Sí, cerrar sesión',
+      cancelButtonText: 'Cancelar'
+    }).then((result) => {
+      if (result.isConfirmed) {
+
+        Swal.fire({
+          title: '¡Sesión cerrada!',
+          text: 'Has cerrado sesión exitosamente',
+          icon: 'success',
+          timer: 750,
+          showConfirmButton: false
+        }).then(() => {
+          navigate('/session-closed');
+        });
+      }
+    });
+  };
 
   // Determina si el menú está seleccionado basado en la ruta actual
   const isSelected = (segment) => {
@@ -216,7 +216,9 @@ const handleLogout = () => {
           ),
         }}
       >
-        <Outlet />
+        <Suspense fallback={<LoadingSpinner />}>
+          <Outlet />
+        </Suspense>
       </DashboardLayout>
     </AppProvider>
   );

--- a/src/components/SidebarLayout.jsx
+++ b/src/components/SidebarLayout.jsx
@@ -1,0 +1,75 @@
+// components/SidebarLayout.jsx
+import React, { Suspense, useMemo, useCallback } from 'react';
+import { Outlet } from 'react-router-dom';
+import { ReactRouterAppProvider } from '@toolpad/core/react-router';
+import { DashboardLayout } from '@toolpad/core/DashboardLayout';
+import { useTheme } from '@mui/material/styles';
+import { IconButton, Tooltip } from '@mui/material';
+import Swal from 'sweetalert2';
+import LoadingSpinner from '../utils/LoadingSpinner';
+import LogoutIcon from '@mui/icons-material/Logout';
+import { NAVIGATION, getBranding } from './sidebarConfig';
+
+export default function SidebarLayout() {
+    const theme = useTheme();
+
+    const branding = useMemo(() => getBranding(theme), [theme]);
+
+    const handleLogout = useCallback(() => {
+        Swal.fire({
+            title: 'Cerrar sesión',
+            text: "¿Estás seguro que deseas salir?",
+            icon: 'question',
+            showCancelButton: true,
+            confirmButtonColor: '#00c3ff',
+            cancelButtonColor: '#d33',
+            confirmButtonText: 'Sí, cerrar sesión',
+            cancelButtonText: 'Cancelar'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                sessionStorage.removeItem('authToken');
+                sessionStorage.removeItem('initialRemainingMinutes');
+
+                Swal.fire({
+                    title: '¡Sesión cerrada!',
+                    text: 'Has cerrado sesión exitosamente',
+                    icon: 'success',
+                    timer: 750,
+                    showConfirmButton: false
+                }).then(() => {
+                    window.location.href = '/session-closed';
+                });
+            }
+        });
+    }, []);
+
+    const toolbarActions = useMemo(() => {
+        return () => (
+            <Tooltip title="Cerrar sesión">
+                <IconButton
+                    onClick={handleLogout}
+                    color="inherit"
+                    sx={{
+                        '&:hover': { backgroundColor: 'rgba(255, 0, 0, 0.1)' }
+                    }}
+                >
+                    <LogoutIcon />
+                </IconButton>
+            </Tooltip>
+        );
+    }, [handleLogout]);
+
+    return (
+        <ReactRouterAppProvider
+            navigation={NAVIGATION}
+            theme={theme}
+            branding={branding}
+        >
+            <DashboardLayout slots={{ toolbarActions }}>
+                <Suspense fallback={<LoadingSpinner />}>
+                    <Outlet />
+                </Suspense>
+            </DashboardLayout>
+        </ReactRouterAppProvider>
+    );
+}

--- a/src/components/sidebarConfig.jsx
+++ b/src/components/sidebarConfig.jsx
@@ -1,0 +1,55 @@
+// components/sidebarConfig.js
+import React from 'react';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import CreateIcon from '@mui/icons-material/Create';
+import DescriptionIcon from '@mui/icons-material/Description';
+import CheckIcon from '@mui/icons-material/Check';
+import SendIcon from '@mui/icons-material/Send';
+import SmsFailedIcon from '@mui/icons-material/SmsFailed';
+import ThumbDownIcon from '@mui/icons-material/ThumbDown';
+import WhatsAppIcon from '@mui/icons-material/WhatsApp';
+import AutoAwesomeMosaicIcon from '@mui/icons-material/AutoAwesomeMosaic';
+import ViewCarouselIcon from '@mui/icons-material/ViewCarousel';
+import AccountTreeIcon from '@mui/icons-material/AccountTree';
+
+// Navegación estática — ReactRouterAppProvider se encarga de resaltar
+// el ítem activo automáticamente basándose en la URL actual.
+export const NAVIGATION = [
+    {
+        segment: 'dashboard',
+        title: 'Dashboard',
+        icon: <DashboardIcon />,
+    },
+    {
+        segment: 'CreateTemplatePage',
+        title: 'Crear Plantillas',
+        icon: <WhatsAppIcon />,
+        children: [
+            { segment: 'CreateTemplatePage', title: 'Texto, imagen y documento', icon: <CreateIcon /> },
+            { segment: 'CreateTemplateCatalog', title: 'Catálogo', icon: <AutoAwesomeMosaicIcon /> },
+            { segment: 'CreateTemplateCarousel', title: 'Carrusel', icon: <ViewCarouselIcon /> },
+            { segment: 'CreateTemplateFlow', title: 'Flow', icon: <AccountTreeIcon /> }
+        ]
+    },
+    { kind: 'divider' },
+    { kind: 'header', title: 'Plantillas' },
+    { segment: 'plantillas', title: 'Todas', icon: <DescriptionIcon />, children: [
+        { segment: 'todas', title: 'Todas', icon: <DescriptionIcon /> },
+        { segment: 'aprobadas', title: 'Aprobadas', icon: <CheckIcon /> },
+        { segment: 'enviadas', title: 'Enviadas', icon: <SendIcon /> },
+        { segment: 'fallidas', title: 'Fallidas', icon: <SmsFailedIcon /> },
+        { segment: 'rechazadas', title: 'Rechazadas', icon: <ThumbDownIcon /> },
+    ]},
+];
+
+export const getBranding = (theme) => ({
+    title: 'TalkMe',
+    logo: (
+        <img
+            src="https://www.talkme.pro/wp-content/uploads/2019/07/logoidentity.png"
+            alt="TalkMe Logo"
+            style={{ width: 'auto', height: 'auto' }}
+        />
+    ),
+    titleStyle: { color: theme.palette.primary.main }
+});

--- a/src/contexts/RouteContext.jsx
+++ b/src/contexts/RouteContext.jsx
@@ -1,0 +1,16 @@
+// contexts/RouteContext.jsx
+import React, { createContext, useContext } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const RouteContext = createContext();
+
+export const RouteProvider = ({ children }) => {
+    const location = useLocation();
+    return (
+        <RouteContext.Provider value={location.pathname}>
+            {children}
+        </RouteContext.Provider>
+    );
+};
+
+export const useCurrentRoute = () => useContext(RouteContext);

--- a/src/pages/TemplateAll.jsx
+++ b/src/pages/TemplateAll.jsx
@@ -1,33 +1,24 @@
-import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useState, useEffect, useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { jwtDecode } from 'jwt-decode';
-import { useParams } from 'react-router-dom';
-import { alpha, Box, Button, Card, CardActions, CardContent, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Fade, FormControl, FormLabel, Input, InputAdornment, ListItemIcon, ListItemText, InputLabel, Menu, MenuItem, OutlinedInput, Select, Stack, styled, TextField, Typography } from '@mui/material';
+import {
+  alpha, Box, FormControl, InputAdornment, InputLabel, Menu, MenuItem,
+  OutlinedInput, Select, styled, ToggleButton, ToggleButtonGroup, Typography, Pagination
+} from '@mui/material';
 import { motion } from 'framer-motion';
-import Swal from 'sweetalert2'
-
-// ICONOS
-import AddIcon from '@mui/icons-material/Add';
-import FindInPageIcon from '@mui/icons-material/FindInPage';
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import ArrowForward from '@mui/icons-material/ArrowForward';
-import Link from '@mui/icons-material/Link';
-import Phone from '@mui/icons-material/Phone';
-import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
-import ErrorIcon from '@mui/icons-material/Error';
+import Swal from 'sweetalert2';
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import ViewListIcon from '@mui/icons-material/ViewList';
 
-// MODAL PARA ELIMINAR
 import DeleteModal from '../components/DeleteModal';
 import { parseTemplateContent } from "../utils/parseTemplateContent";
 import { fetchMergedTemplates } from '../api/templatesServices';
 
-import TemplateCardSkeleton from '../utils/SkeletonTemplates';
 import CardBase from '../components/CardBase';
 import CardBaseCarousel from '../components/CardBaseCarousel';
 import CardBaseSkeleton from '../components/CardBaseSkeleton';
+import ListBase from '../components/ListBase';
 
 const TemplateAll = () => {
   const { templateId } = useParams();
@@ -40,96 +31,33 @@ const TemplateAll = () => {
   const [tipoPlantillaFiltro, setTipoPlantillaFiltro] = useState('ALL');
   const [categoriaFiltro, setCategoriaFiltro] = useState('ALL');
   const [busquedaFiltro, setBusquedaFiltro] = useState('');
+  const [viewMode, setViewMode] = useState('grid');
+
+  // 🆕 Estados y constantes para paginación
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 12; // Puedes ajustar este valor (9, 12, 15, etc.)
 
   const navigate = useNavigate();
 
-  const token = sessionStorage.getItem('authToken');
-
-  let appId, authCode, urlTemplatesGS;
-  if (token) {
+  const { appId, authCode, urlTemplatesGS } = useMemo(() => {
+    const token = sessionStorage.getItem('authToken');
+    if (!token) return {};
     try {
       const decoded = jwtDecode(token);
-      appId = decoded.app_id;
-      authCode = decoded.auth_code;
-      urlTemplatesGS = decoded.urlTemplatesGS;
-    } catch (error) {
-      console.error('Error decodificando el token:', error);
+      return {
+        appId: decoded.app_id,
+        authCode: decoded.auth_code,
+        urlTemplatesGS: decoded.urlTemplatesGS,
+      };
+    } catch {
+      return {};
     }
-  }
-
-  /*
-  let appId, authCode, appName, idUsuarioTalkMe, idNombreUsuarioTalkMe, empresaTalkMe, urlTemplatesGS;
-
-  appId = '1fbd9a1e-074c-4e1e-801c-b25a0fcc9487'; // Extrae appId del token
-  authCode = 'sk_d416c60960504bab8be8bc3fac11a358'; // Extrae authCode del token
-  appName = 'DemosTalkMe55'; // Extrae el nombre de la aplicación
-  idUsuarioTalkMe = 78;  // Cambiado de idUsuario a id_usuario
-  idNombreUsuarioTalkMe = 'javier.colocho';  // Cambiado de nombreUsuario a nombre_usuario
-  empresaTalkMe = 2;
-  urlTemplatesGS = 'https://dev.talkme.pro/templatesGS/api/';
-
-  */
-
-  /* Función para obtener las plantillas
-  const fetchTemplates = async (appId, authCode) => {
-    try {
-      const response = await fetch(`https://partner.gupshup.io/partner/app/${appId}/templates`, {
-        method: 'GET',
-        headers: {
-          Authorization: authCode,
-        },
-      });
-      const data = await response.json();
-      if (data.status === 'success') {
-        return data.templates;
-      }
-      return []; // Retorna un array vacío si no hay éxito
-    } catch (error) {
-      console.error('Error fetching templates:', error);
-      return []; // Retorna un array vacío en caso de error
-    }
-  };
-
-  // useEffect para cargar datos
-  useEffect(() => {
-    if (appId && authCode) {
-      setLoading(true); // Asegúrate de que loading esté en true al inicio
-      fetchTemplates(appId, authCode)
-        .then(data => {
-          setTemplates(data);
-          setLoading(false);
-        });
-    } else {
-      console.error('No se encontró appId o authCode en el token');
-    }
-  }, [appId, authCode]);
-
-  useEffect(() => {
-    let filtered = [...templates];
-
-    if (tipoPlantillaFiltro !== 'ALL') {
-      filtered = filtered.filter(template => template.templateType === tipoPlantillaFiltro);
-    }
-
-    if (categoriaFiltro && categoriaFiltro !== 'ALL') {
-      filtered = filtered.filter(template => template.category === categoriaFiltro);
-    }
-
-    if (busquedaFiltro.trim() !== '') {
-      filtered = filtered.filter(template =>
-        template.elementName.toLowerCase().includes(busquedaFiltro.toLowerCase())
-      );
-    }
-
-    setFilteredTemplates(filtered);
-  }, [tipoPlantillaFiltro, categoriaFiltro, busquedaFiltro, templates]);
-
-  */
+  }, []);
 
   const obtenerTemplatesMerge = async () => {
     try {
-      const templates = await fetchMergedTemplates(appId, authCode, urlTemplatesGS);
-      return templates;
+      const data = await fetchMergedTemplates(appId, authCode, urlTemplatesGS);
+      return data;
     } catch (error) {
       console.error('Error al obtener templates:', error);
       return [];
@@ -137,16 +65,12 @@ const TemplateAll = () => {
   };
 
   useEffect(() => {
-    if (appId && authCode && urlTemplatesGS) {
-      setLoading(true);
-      obtenerTemplatesMerge()
-        .then(data => {
-          setTemplates(data);
-          setLoading(false);
-        });
-    } else {
-      console.error('No se encontró appId, authCode o urlTemplatesGS en el token');
-    }
+    if (!appId || !authCode || !urlTemplatesGS) return;
+    setLoading(true);
+    obtenerTemplatesMerge().then(data => {
+      setTemplates(data);
+      setLoading(false);
+    });
   }, [appId, authCode, urlTemplatesGS]);
 
   useEffect(() => {
@@ -156,7 +80,7 @@ const TemplateAll = () => {
       if (tipoPlantillaFiltro === 'FLOW') {
         filtered = filtered.filter(template => template.gupshup.buttonSupported === 'FLOW');
       } else {
-        filtered = filtered.filter(template => 
+        filtered = filtered.filter(template =>
           template.gupshup.templateType === tipoPlantillaFiltro &&
           template.gupshup.buttonSupported !== 'FLOW'
         );
@@ -176,82 +100,67 @@ const TemplateAll = () => {
     setFilteredTemplates(filtered);
   }, [tipoPlantillaFiltro, categoriaFiltro, busquedaFiltro, templates]);
 
+  // 🆕 Reiniciar a página 1 cuando cambien los filtros
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [tipoPlantillaFiltro, categoriaFiltro, busquedaFiltro]);
+
+  // 🆕 Cálculo de elementos actuales y total de páginas
+  const indexOfLastItem = currentPage * itemsPerPage;
+  const indexOfFirstItem = indexOfLastItem - itemsPerPage;
+  const currentItems = filteredTemplates.slice(indexOfFirstItem, indexOfLastItem);
+  const totalPages = Math.ceil(filteredTemplates.length / itemsPerPage);
+
   const handleFiltrarTipoPlantilla = (event) => {
     setTipoPlantillaFiltro(event.target.value);
-  }
+  };
 
   const handleFiltrarCategoriaPlantilla = (event) => {
     setCategoriaFiltro(event.target.value);
-  }
+  };
 
   const getStatusColor = (status) => {
     switch (status) {
-      case 'REJECTED':
-        return '#ffebee';
-      case 'FAILED':
-        return '#fff3e0';
-      case 'APPROVED':
-        return '#C8E6C9';
-      default:
-        return '#f5f5f5';
+      case 'REJECTED': return '#ffebee';
+      case 'FAILED': return '#fff3e0';
+      case 'APPROVED': return '#C8E6C9';
+      default: return '#f5f5f5';
     }
   };
 
   const getStatusTextColor = (status) => {
     switch (status) {
-      case 'REJECTED':
-        return '#d32f2f';
-      case 'FAILED':
-        return '#e65100';
-      case 'APPROVED':
-        return '#1B5E20';
-      default:
-        return '#616161';
+      case 'REJECTED': return '#d32f2f';
+      case 'FAILED': return '#e65100';
+      case 'APPROVED': return '#1B5E20';
+      default: return '#616161';
     }
   };
 
   const getStatusDotColor = (status) => {
     switch (status) {
-      case 'REJECTED':
-        return '#EF4444';
-      case 'FAILED':
-        return '#FF9900';
-      case 'APPROVED':
-        return '#34C759';
-      default:
-        return '#000000';
+      case 'REJECTED': return '#EF4444';
+      case 'FAILED': return '#FF9900';
+      case 'APPROVED': return '#34C759';
+      default: return '#000000';
     }
   };
 
   const [anchorEl, setAnchorEl] = useState(null);
-
   const handleClick = (event, template) => {
     setAnchorEl(event.currentTarget);
     setSelectedTemplate(template);
   };
 
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
+  const handleClose = () => setAnchorEl(null);
 
   const handleEdit = (template) => {
-    if (template.gupshup.status === "APPROVED" || template.gupshup.status === "REJECTED" || template.gupshup.status === "PAUSED") {
-      switch (template.gupshup.templateType) {
-        case 'CAROUSEL':
-          navigate('/modify-template-carousel', { state: { template } });
-          break;
-        case 'CATALOG':
-          navigate('/modify-template-catalogo', { state: { template } });
-          break;
-        case 'TEXT':
-        case 'IMAGE':
-        case 'DOCUMENT':
-        case 'VIDEO':
-          navigate('/modify-template', { state: { template } });
-          break;
-        default:
-          navigate('/modify-template', { state: { template } });
-      }
+    if (["APPROVED", "REJECTED", "PAUSED"].includes(template.gupshup.status)) {
+      const routeMap = {
+        CAROUSEL: '/modify-template-carousel',
+        CATALOG: '/modify-template-catalogo',
+      };
+      navigate(routeMap[template.gupshup.templateType] || '/modify-template', { state: { template } });
     } else {
       Swal.fire({
         title: 'La plantilla no puede ser editada.',
@@ -278,16 +187,14 @@ const TemplateAll = () => {
       setDeleteModalOpen(false);
       setSelectedTemplate(null);
       setLoading(true);
-
       const newTemplates = await obtenerTemplatesMerge();
-
       setTemplates(newTemplates);
       setLoading(false);
     } catch (error) {
       console.error('Error al eliminar la plantilla:', error);
       Swal.fire({
-        title: 'La plantilla no puedo ser eliminada.',
-        text: 'No se puede eliminar la plantilla.',
+        title: 'La plantilla no pudo ser eliminada.',
+        text: 'Ocurrió un error al intentar eliminar la plantilla.',
         icon: 'error',
         confirmButtonText: 'Cerrar',
         confirmButtonColor: '#00c3ff'
@@ -302,14 +209,8 @@ const TemplateAll = () => {
   const StyledMenu = styled((props) => (
     <Menu
       elevation={0}
-      anchorOrigin={{
-        vertical: 'bottom',
-        horizontal: 'right',
-      }}
-      transformOrigin={{
-        vertical: 'top',
-        horizontal: 'right',
-      }}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'right' }}
       {...props}
     />
   ))(({ theme }) => ({
@@ -318,29 +219,17 @@ const TemplateAll = () => {
       marginTop: theme.spacing(1),
       minWidth: 180,
       color: 'rgb(55, 65, 81)',
-      boxShadow:
-        'rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px',
-      '& .MuiMenu-list': {
-        padding: '4px 0',
-      },
+      boxShadow: 'rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px',
+      '& .MuiMenu-list': { padding: '4px 0' },
       '& .MuiMenuItem-root': {
-        '& .MuiSvgIcon-root': {
-          fontSize: 18,
-          color: theme.palette.text.secondary,
-          marginRight: theme.spacing(1.5),
-        },
-        '&:active': {
-          backgroundColor: alpha(
-            theme.palette.primary.main,
-            theme.palette.action.selectedOpacity,
-          ),
-        },
-      },
-    },
+        '& .MuiSvgIcon-root': { fontSize: 18, color: theme.palette.text.secondary, marginRight: theme.spacing(1.5) },
+        '&:active': { backgroundColor: alpha(theme.palette.primary.main, theme.palette.action.selectedOpacity) }
+      }
+    }
   }));
 
-  const [openReasonDialog, setOpenReasonDialog] = React.useState(false);
-  const [selectedReason, setSelectedReason] = React.useState('');
+  const [openReasonDialog, setOpenReasonDialog] = useState(false);
+  const [selectedReason, setSelectedReason] = useState('');
 
   const handleOpenReasonDialog = (reason) => {
     setSelectedReason(reason);
@@ -357,31 +246,17 @@ const TemplateAll = () => {
       confirmButtonText: 'Entendido',
       confirmButtonColor: '#00c3ff',
       focusConfirm: false,
-      customClass: {
-        title: 'swal2-title-custom'
-      }
     });
   };
 
   const containerVariants = {
     hidden: { opacity: 0 },
-    visible: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.1
-      }
-    }
+    visible: { opacity: 1, transition: { staggerChildren: 0.1 } }
   };
 
   const cardVariants = {
     hidden: { opacity: 0, y: 20 },
-    visible: {
-      opacity: 1,
-      y: 0,
-      transition: {
-        duration: 0.5
-      }
-    }
+    visible: { opacity: 1, y: 0, transition: { duration: 0.5 } }
   };
 
   const CardComponents = {
@@ -389,39 +264,67 @@ const TemplateAll = () => {
     DEFAULT: CardBase,
   };
 
+  // 🆕 Manejador de cambio de página
+  const handlePageChange = (event, value) => {
+    setCurrentPage(value);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const handleViewChange = (event, newView) => {
+    if (newView !== null) {
+      setViewMode(newView);
+    }
+  };
+
   return (
     <Box>
       <Box sx={{ display: 'flex' }}>
         <Box sx={{ flexGrow: 1, p: 3 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexGrow: 1, p: 3 }}>
-            {/* Título */}<Typography variant="h4" gutterBottom>
+            <Typography variant="h4" gutterBottom>
               Catálogo de Plantillas
             </Typography>
 
+            <ToggleButtonGroup
+              value={viewMode}
+              exclusive
+              onChange={handleViewChange}
+              aria-label="vista"
+              size="small"
+              sx={{
+                marginLeft: { xs: 0, md: 'auto' },
+                '& .MuiToggleButton-root': {
+                  px: 2,
+                  py: 0.5
+                }
+              }}
+            >
+              <ToggleButton value="grid" aria-label="vista grid">
+                <ViewModuleIcon />
+              </ToggleButton>
+              <ToggleButton value="list" aria-label="vista lista">
+                <ViewListIcon />
+              </ToggleButton>
+            </ToggleButtonGroup>
+
             <FormControl variant="outlined" sx={{ marginLeft: 'auto', minWidth: 400 }}>
-              <InputLabel htmlFor="input-with-icon-adornment">
-                Buscar plantillas por nombre
-              </InputLabel>
+              <InputLabel htmlFor="input-with-icon-adornment">Buscar plantillas por nombre</InputLabel>
               <OutlinedInput
                 id="input-with-icon-adornment"
-                endAdornment={
-                  <InputAdornment position="end">
-                    <SearchOutlinedIcon />
-                  </InputAdornment>
-                }
-                label="With an end adornment"
+                endAdornment={<InputAdornment position="end"><SearchOutlinedIcon /></InputAdornment>}
+                label="Buscar plantillas por nombre"
                 value={busquedaFiltro}
                 onChange={(e) => setBusquedaFiltro(e.target.value)}
               />
             </FormControl>
 
             <FormControl sx={{ minWidth: 200 }}>
-              <InputLabel id="Categoria">Categoría</InputLabel>
+              <InputLabel id="categoria-label">Categoría</InputLabel>
               <Select
                 labelId="categoria-label"
                 id="categoria-select"
                 value={categoriaFiltro}
-                label="Categoria"
+                label="Categoría"
                 onChange={handleFiltrarCategoriaPlantilla}
               >
                 <MenuItem value='ALL'>Todas</MenuItem>
@@ -431,7 +334,7 @@ const TemplateAll = () => {
             </FormControl>
 
             <FormControl sx={{ minWidth: 200 }}>
-              <InputLabel id="Tipo">Tipo</InputLabel>
+              <InputLabel id="tipo-label">Tipo</InputLabel>
               <Select
                 labelId="tipo-label"
                 id="tipo-select"
@@ -444,65 +347,109 @@ const TemplateAll = () => {
                 <MenuItem value='IMAGE'>Imagen</MenuItem>
                 <MenuItem value='VIDEO'>Video</MenuItem>
                 <MenuItem value='DOCUMENT'>Documento</MenuItem>
-                <MenuItem value='CATALOG'>Cátalogo</MenuItem>
+                <MenuItem value='CATALOG'>Catálogo</MenuItem>
                 <MenuItem value='CAROUSEL'>Carrusel</MenuItem>
                 <MenuItem value='FLOW'>Flow</MenuItem>
               </Select>
             </FormControl>
           </Box>
 
-          {/* Grid de tarjetas */}
+          {/* Contenido de plantillas */}
+          {loading ? (
+            <Box sx={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
+              gap: 3,
+              justifyItems: "center"
+            }}>
+              {Array.from({ length: 4 }).map((_, index) => <CardBaseSkeleton key={index} />)}
+            </Box>
+          ) : currentItems.length > 0 ? (
+            viewMode === 'grid' ? (
+              /* 👇 VISTA GRID */
+              <Box sx={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
+                gap: 3,
+                justifyItems: "center"
+              }}>
+                {currentItems.map((template) => {
+                  const CardComponent = CardComponents[template.gupshup.templateType] || CardComponents.DEFAULT;
+                  return (
+                    <motion.div
+                      key={template.gupshup.id || template.id}
+                      variants={cardVariants}
+                      whileHover={{ scale: 1.05, y: -10, transition: { duration: 0.2 } }}
+                      whileTap={{ scale: 0.98 }}
+                    >
+                      <CardComponent
+                        template={template}
+                        handleEdit={handleEdit}
+                        handleDeleteClick={handleDeleteClick}
+                        showReasonAlert={showReasonAlert}
+                        parseTemplateContent={parseTemplateContent}
+                        getStatusColor={getStatusColor}
+                        getStatusDotColor={getStatusDotColor}
+                        getStatusTextColor={getStatusTextColor}
+                      />
+                    </motion.div>
+                  );
+                })}
+              </Box>
+            ) : (
+              /* 👇 VISTA LISTA */
+              <ListBase
+                templates={currentItems}
+                handleEdit={handleEdit}
+                handleDeleteClick={handleDeleteClick}
+                showReasonAlert={showReasonAlert}
+                parseTemplateContent={parseTemplateContent}
+                getStatusColor={getStatusColor}
+                getStatusDotColor={getStatusDotColor}
+                getStatusTextColor={getStatusTextColor}
+              />
+            )
+          ) : (
+            /* Estado vacío para ambas vistas */
+            <Box sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              minHeight: 300,
+              textAlign: 'center',
+              p: 4
+            }}>
+              <Typography variant="h6" sx={{ color: 'text.secondary' }}>
+                No se encontraron plantillas con los filtros actuales.
+              </Typography>
+            </Box>
+          )}
 
-          <Box sx={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
-            gap: 3,
-            justifyItems: "center"
-          }}>
-            {loading ?
-              Array.from(new Array(4)).map((_, index) => (
-                <CardBaseSkeleton key={index} />
-              ))
-              :
-              filteredTemplates.map((template) => {
-                const CardComponent = CardComponents[template.gupshup.templateType] || CardComponents.DEFAULT;
+          {/* Paginación */}
+          {totalPages > 1 && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 5, mb: 3 }}>
+              <Pagination
+                count={totalPages}
+                page={currentPage}
+                onChange={handlePageChange}
+                color="primary"
+                size="large"
+                shape="rounded"
+                siblingCount={1}
+                boundaryCount={1}
+              />
+            </Box>
+          )}
 
-                return (
-                  <motion.div
-                    key={template.id}
-                    variants={cardVariants}
-                    whileHover={{
-                      scale: 1.05,
-                      y: -10,
-                      transition: { duration: 0.2 }
-                    }}
-                    whileTap={{ scale: 0.98 }}
-                  >
-                    <CardComponent
-                      key={template.id}
-                      template={template}
-                      handleEdit={handleEdit}
-                      handleDeleteClick={handleDeleteClick}
-                      showReasonAlert={showReasonAlert}
-                      parseTemplateContent={parseTemplateContent}
-                      getStatusColor={getStatusColor}
-                      getStatusDotColor={getStatusDotColor}
-                      getStatusTextColor={getStatusTextColor}
-                    />
-                  </motion.div>
-                );
-              })}
-          </Box>
-
+          <DeleteModal
+            open={deleteModalOpen}
+            onClose={handleDeleteCancel}
+            onConfirm={handleDeleteConfirm}
+            template={selectedTemplate}
+          />
         </Box>
       </Box>
-      {/* Modal de Eliminación */}
-      <DeleteModal
-        open={deleteModalOpen}
-        onClose={handleDeleteCancel}
-        onConfirm={handleDeleteConfirm}
-        template={selectedTemplate}
-      />
     </Box>
   );
 };

--- a/src/pages/TemplateAproved.jsx
+++ b/src/pages/TemplateAproved.jsx
@@ -1,33 +1,21 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
-import { alpha, Box, Button, Card, CardActions, CardContent, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Fade, FormControl, FormLabel, Input, InputAdornment, ListItemIcon, ListItemText, InputLabel, Menu, MenuItem, OutlinedInput, Select, Stack, styled, TextField, Typography } from '@mui/material';
+import { alpha, Box, FormControl, InputAdornment, InputLabel, Menu, MenuItem, OutlinedInput, Pagination, Select, styled, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
-import Sidebar from '../components/Sidebar';
 import { jwtDecode } from 'jwt-decode';
 import { motion } from 'framer-motion';
 
-// ICONOS
-import AddIcon from '@mui/icons-material/Add';
-import FindInPageIcon from '@mui/icons-material/FindInPage';
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import ArrowForward from '@mui/icons-material/ArrowForward';
-import Link from '@mui/icons-material/Link';
-import Phone from '@mui/icons-material/Phone';
-import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
-import ErrorIcon from '@mui/icons-material/Error';
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import ViewListIcon from '@mui/icons-material/ViewList';
 
-// MODAL PARA ELIMINAR
 import DeleteModal from '../components/DeleteModal';
 import { parseTemplateContent } from "../utils/parseTemplateContent";
+import { fetchMergedTemplates } from '../api/templatesServices';
 import CardBase from '../components/CardBase';
 import CardBaseCarousel from '../components/CardBaseCarousel';
 import CardBaseSkeleton from '../components/CardBaseSkeleton';
-
-import TemplateCardSkeleton from '../utils/SkeletonTemplates';
-import { fetchMergedTemplates } from '../api/templatesServices';
+import ListBase from '../components/ListBase';
 
 const TemplateAproved = () => {
   const { templateId } = useParams();
@@ -40,22 +28,28 @@ const TemplateAproved = () => {
   const [tipoPlantillaFiltro, setTipoPlantillaFiltro] = useState('ALL');
   const [categoriaFiltro, setCategoriaFiltro] = useState('ALL');
   const [busquedaFiltro, setBusquedaFiltro] = useState('');
+  const [viewMode, setViewMode] = useState('grid');
+
+  // 🆕 Estados y constantes para paginación
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 12; // Puedes ajustar este valor (9, 12, 15, etc.)
 
   const navigate = useNavigate();
 
-  const token = sessionStorage.getItem('authToken');
-
-  let appId, authCode, urlTemplatesGS;
-  if (token) {
+  const { appId, authCode, urlTemplatesGS } = useMemo(() => {
+    const token = sessionStorage.getItem('authToken');
+    if (!token) return {};
     try {
       const decoded = jwtDecode(token);
-      appId = decoded.app_id;
-      authCode = decoded.auth_code;
-      urlTemplatesGS = decoded.urlTemplatesGS;
-    } catch (error) {
-      console.error('Error decodificando el token:', error);
+      return {
+        appId: decoded.app_id,
+        authCode: decoded.auth_code,
+        urlTemplatesGS: decoded.urlTemplatesGS,
+      };
+    } catch {
+      return {};
     }
-  }
+  }, [])
 
   const obtenerTemplatesMerge = async () => {
     try {
@@ -71,44 +65,51 @@ const TemplateAproved = () => {
   };
 
   useEffect(() => {
-    if (appId && authCode && urlTemplatesGS) {
-      setLoading(true);
-      obtenerTemplatesMerge()
-        .then(data => {
-          setTemplates(data);
-          setLoading(false);
-        });
-    } else {
-      console.error('No se encontró appId, authCode o urlTemplatesGS en el token');
-    }
+    if (!appId || !authCode || !urlTemplatesGS) return;
+    setLoading(true);
+    obtenerTemplatesMerge().then(data => {
+      setTemplates(data);
+      setLoading(false);
+    });
   }, [appId, authCode, urlTemplatesGS]);
 
   useEffect(() => {
-      let filtered = [...templates];
-  
-      if (tipoPlantillaFiltro !== 'ALL') {
-        if (tipoPlantillaFiltro === 'FLOW') {
-          filtered = filtered.filter(template => template.gupshup.buttonSupported === 'FLOW');
-        } else {
-          filtered = filtered.filter(template => 
-            template.gupshup.templateType === tipoPlantillaFiltro &&
-            template.gupshup.buttonSupported !== 'FLOW'
-          );
-        }
-      }
-  
-      if (categoriaFiltro && categoriaFiltro !== 'ALL') {
-        filtered = filtered.filter(template => template.gupshup.category === categoriaFiltro);
-      }
-  
-      if (busquedaFiltro.trim() !== '') {
+    let filtered = [...templates];
+
+    if (tipoPlantillaFiltro !== 'ALL') {
+      if (tipoPlantillaFiltro === 'FLOW') {
+        filtered = filtered.filter(template => template.gupshup.buttonSupported === 'FLOW');
+      } else {
         filtered = filtered.filter(template =>
-          template.gupshup.elementName.toLowerCase().includes(busquedaFiltro.toLowerCase())
+          template.gupshup.templateType === tipoPlantillaFiltro &&
+          template.gupshup.buttonSupported !== 'FLOW'
         );
       }
-  
-      setFilteredTemplates(filtered);
-    }, [tipoPlantillaFiltro, categoriaFiltro, busquedaFiltro, templates]);
+    }
+
+    if (categoriaFiltro && categoriaFiltro !== 'ALL') {
+      filtered = filtered.filter(template => template.gupshup.category === categoriaFiltro);
+    }
+
+    if (busquedaFiltro.trim() !== '') {
+      filtered = filtered.filter(template =>
+        template.gupshup.elementName.toLowerCase().includes(busquedaFiltro.toLowerCase())
+      );
+    }
+
+    setFilteredTemplates(filtered);
+  }, [tipoPlantillaFiltro, categoriaFiltro, busquedaFiltro, templates]);
+
+  // 🆕 Reiniciar a página 1 cuando cambien los filtros
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [tipoPlantillaFiltro, categoriaFiltro, busquedaFiltro]);
+
+  // 🆕 Cálculo de elementos actuales y total de páginas
+  const indexOfLastItem = currentPage * itemsPerPage;
+  const indexOfFirstItem = indexOfLastItem - itemsPerPage;
+  const currentItems = filteredTemplates.slice(indexOfFirstItem, indexOfLastItem);
+  const totalPages = Math.ceil(filteredTemplates.length / itemsPerPage);
 
   const handleFiltrarTipoPlantilla = (event) => {
     setTipoPlantillaFiltro(event.target.value);
@@ -324,6 +325,18 @@ const TemplateAproved = () => {
     DEFAULT: CardBase,
   };
 
+  // 🆕 Manejador de cambio de página
+  const handlePageChange = (event, value) => {
+    setCurrentPage(value);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const handleViewChange = (event, newView) => {
+    if (newView !== null) {
+      setViewMode(newView);
+    }
+  };
+
   return (
     <Box>
       <Box sx={{ display: 'flex' }}>
@@ -333,6 +346,28 @@ const TemplateAproved = () => {
             {/* Título */}<Typography variant="h4" gutterBottom>
               Catálogo de Plantillas
             </Typography>
+
+            <ToggleButtonGroup
+              value={viewMode}
+              exclusive
+              onChange={handleViewChange}
+              aria-label="vista"
+              size="small"
+              sx={{
+                marginLeft: { xs: 0, md: 'auto' },
+                '& .MuiToggleButton-root': {
+                  px: 2,
+                  py: 0.5
+                }
+              }}
+            >
+              <ToggleButton value="grid" aria-label="vista grid">
+                <ViewModuleIcon />
+              </ToggleButton>
+              <ToggleButton value="list" aria-label="vista lista">
+                <ViewListIcon />
+              </ToggleButton>
+            </ToggleButtonGroup>
 
             <FormControl variant="outlined" sx={{ marginLeft: 'auto', minWidth: 400 }}>
               <InputLabel htmlFor="input-with-icon-adornment">
@@ -387,61 +422,102 @@ const TemplateAproved = () => {
             </FormControl>
           </Box>
 
-          {/* Grid de tarjetas */}
-          <Box sx={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
-            gap: 3,
-            justifyItems: "center"
-          }}>
-            {loading ?
-              Array.from(new Array(4)).map((_, index) => (
-                <CardBaseSkeleton key={index} />
-              ))
-              :
-              filteredTemplates.map((template) => {
-                const CardComponent = CardComponents[template.gupshup.templateType] || CardComponents.DEFAULT;
+          {/* Contenido de plantillas */}
+          {loading ? (
+            <Box sx={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
+              gap: 3,
+              justifyItems: "center"
+            }}>
+              {Array.from({ length: 4 }).map((_, index) => <CardBaseSkeleton key={index} />)}
+            </Box>
+          ) : currentItems.length > 0 ? (
+            viewMode === 'grid' ? (
+              /* 👇 VISTA GRID */
+              <Box sx={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
+                gap: 3,
+                justifyItems: "center"
+              }}>
+                {currentItems.map((template) => {
+                  const CardComponent = CardComponents[template.gupshup.templateType] || CardComponents.DEFAULT;
+                  return (
+                    <motion.div
+                      key={template.gupshup.id || template.id}
+                      variants={cardVariants}
+                      whileHover={{ scale: 1.05, y: -10, transition: { duration: 0.2 } }}
+                      whileTap={{ scale: 0.98 }}
+                    >
+                      <CardComponent
+                        template={template}
+                        handleEdit={handleEdit}
+                        handleDeleteClick={handleDeleteClick}
+                        showReasonAlert={showReasonAlert}
+                        parseTemplateContent={parseTemplateContent}
+                        getStatusColor={getStatusColor}
+                        getStatusDotColor={getStatusDotColor}
+                        getStatusTextColor={getStatusTextColor}
+                      />
+                    </motion.div>
+                  );
+                })}
+              </Box>
+            ) : (
+              /* 👇 VISTA LISTA */
+              <ListBase
+                templates={currentItems}
+                handleEdit={handleEdit}
+                handleDeleteClick={handleDeleteClick}
+                showReasonAlert={showReasonAlert}
+                parseTemplateContent={parseTemplateContent}
+                getStatusColor={getStatusColor}
+                getStatusDotColor={getStatusDotColor}
+                getStatusTextColor={getStatusTextColor}
+              />
+            )
+          ) : (
+            /* Estado vacío para ambas vistas */
+            <Box sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              minHeight: 300,
+              textAlign: 'center',
+              p: 4
+            }}>
+              <Typography variant="h6" sx={{ color: 'text.secondary' }}>
+                No se encontraron plantillas con los filtros actuales.
+              </Typography>
+            </Box>
+          )}
 
-                return (
-                  <motion.div
-                    key={template.id}
-                    variants={cardVariants}
-                    whileHover={{
-                      scale: 1.05,
-                      y: -10,
-                      transition: { duration: 0.2 }
-                    }}
-                    whileTap={{ scale: 0.98 }}
-                  >
-                    <CardComponent
-                      key={template.id}
-                      template={template}
-                      handleEdit={handleEdit}
-                      handleDeleteClick={handleDeleteClick}
-                      showReasonAlert={showReasonAlert}
-                      parseTemplateContent={parseTemplateContent}
-                      getStatusColor={getStatusColor}
-                      getStatusDotColor={getStatusDotColor}
-                      getStatusTextColor={getStatusTextColor}
-                    />
-                  </motion.div>
-                );
-              })}
-          </Box>
+          {/* Paginación */}
+          {totalPages > 1 && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 5, mb: 3 }}>
+              <Pagination
+                count={totalPages}
+                page={currentPage}
+                onChange={handlePageChange}
+                color="primary"
+                size="large"
+                shape="rounded"
+                siblingCount={1}
+                boundaryCount={1}
+              />
+            </Box>
+          )}
 
-
-
-
+          <DeleteModal
+            open={deleteModalOpen}
+            onClose={handleDeleteCancel}
+            onConfirm={handleDeleteConfirm}
+            template={selectedTemplate}
+          />
         </Box>
       </Box>
-
-      {/* Modal de Eliminación */}
-      <DeleteModal
-        open={deleteModalOpen}
-        onClose={handleDeleteCancel}
-        onConfirm={handleDeleteConfirm}
-        template={selectedTemplate}
-      />
     </Box>
   );
 };

--- a/src/pages/TemplateFailed.jsx
+++ b/src/pages/TemplateFailed.jsx
@@ -1,34 +1,24 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
-import { alpha, Box, Button, Card, CardActions, CardContent, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Fade, FormControl, FormLabel, Input, InputAdornment, ListItemIcon, ListItemText, InputLabel, Menu, MenuItem, OutlinedInput, Select, Stack, styled, TextField, Typography } from '@mui/material';
+import { alpha, Box, FormControl, InputAdornment, InputLabel, Menu, MenuItem, OutlinedInput, Select, styled, ToggleButton, ToggleButtonGroup, Typography, Pagination } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
-import Sidebar from '../components/Sidebar';
 import { jwtDecode } from 'jwt-decode';
 import { motion } from 'framer-motion';
 import Swal from 'sweetalert2'
-
-// ICONOS
-import AddIcon from '@mui/icons-material/Add';
-import FindInPageIcon from '@mui/icons-material/FindInPage';
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import ArrowForward from '@mui/icons-material/ArrowForward';
-import Link from '@mui/icons-material/Link';
-import Phone from '@mui/icons-material/Phone';
-import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
-import ErrorIcon from '@mui/icons-material/Error';
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import ViewListIcon from '@mui/icons-material/ViewList';
 
 // MODAL PARA ELIMINAR
 import DeleteModal from '../components/DeleteModal';
 import { parseTemplateContent } from "../utils/parseTemplateContent";
+import { fetchMergedTemplates } from '../api/templatesServices';
 
-import TemplateCardSkeleton from '../utils/SkeletonTemplates';
 import CardBase from '../components/CardBase';
 import CardBaseCarousel from '../components/CardBaseCarousel';
 import CardBaseSkeleton from '../components/CardBaseSkeleton';
-import { fetchMergedTemplates } from '../api/templatesServices';
+import ListBase from '../components/ListBase';
+
 
 const TemplateAproved = () => {
   const { templateId } = useParams();
@@ -41,22 +31,30 @@ const TemplateAproved = () => {
   const [tipoPlantillaFiltro, setTipoPlantillaFiltro] = useState('ALL');
   const [categoriaFiltro, setCategoriaFiltro] = useState('ALL');
   const [busquedaFiltro, setBusquedaFiltro] = useState('');
+  const [viewMode, setViewMode] = useState('grid');
+
+  // 🆕 Estados y constantes para paginación
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 12; // Puedes ajustar este valor (9, 12, 15, etc.)
 
   const navigate = useNavigate();
 
   const token = sessionStorage.getItem('authToken');
 
-  let appId, authCode, urlTemplatesGS;
-  if (token) {
+  const { appId, authCode, urlTemplatesGS } = useMemo(() => {
+    const token = sessionStorage.getItem('authToken');
+    if (!token) return {};
     try {
       const decoded = jwtDecode(token);
-      appId = decoded.app_id;
-      authCode = decoded.auth_code;
-      urlTemplatesGS = decoded.urlTemplatesGS;
-    } catch (error) {
-      console.error('Error decodificando el token:', error);
+      return {
+        appId: decoded.app_id,
+        authCode: decoded.auth_code,
+        urlTemplatesGS: decoded.urlTemplatesGS,
+      };
+    } catch {
+      return {};
     }
-  }
+  }, [])
 
   const obtenerTemplatesMerge = async () => {
     try {
@@ -72,44 +70,51 @@ const TemplateAproved = () => {
   };
 
   useEffect(() => {
-    if (appId && authCode && urlTemplatesGS) {
-      setLoading(true);
-      obtenerTemplatesMerge()
-        .then(data => {
-          setTemplates(data);
-          setLoading(false);
-        });
-    } else {
-      console.error('No se encontró appId, authCode o urlTemplatesGS en el token');
-    }
+    if (!appId || !authCode || !urlTemplatesGS) return;
+    setLoading(true);
+    obtenerTemplatesMerge().then(data => {
+      setTemplates(data);
+      setLoading(false);
+    });
   }, [appId, authCode, urlTemplatesGS]);
 
   useEffect(() => {
-        let filtered = [...templates];
-    
-        if (tipoPlantillaFiltro !== 'ALL') {
-          if (tipoPlantillaFiltro === 'FLOW') {
-            filtered = filtered.filter(template => template.gupshup.buttonSupported === 'FLOW');
-          } else {
-            filtered = filtered.filter(template => 
-              template.gupshup.templateType === tipoPlantillaFiltro &&
-              template.gupshup.buttonSupported !== 'FLOW'
-            );
-          }
-        }
-    
-        if (categoriaFiltro && categoriaFiltro !== 'ALL') {
-          filtered = filtered.filter(template => template.gupshup.category === categoriaFiltro);
-        }
-    
-        if (busquedaFiltro.trim() !== '') {
-          filtered = filtered.filter(template =>
-            template.gupshup.elementName.toLowerCase().includes(busquedaFiltro.toLowerCase())
-          );
-        }
-    
-        setFilteredTemplates(filtered);
-      }, [tipoPlantillaFiltro, categoriaFiltro, busquedaFiltro, templates]);
+    let filtered = [...templates];
+
+    if (tipoPlantillaFiltro !== 'ALL') {
+      if (tipoPlantillaFiltro === 'FLOW') {
+        filtered = filtered.filter(template => template.gupshup.buttonSupported === 'FLOW');
+      } else {
+        filtered = filtered.filter(template =>
+          template.gupshup.templateType === tipoPlantillaFiltro &&
+          template.gupshup.buttonSupported !== 'FLOW'
+        );
+      }
+    }
+
+    if (categoriaFiltro && categoriaFiltro !== 'ALL') {
+      filtered = filtered.filter(template => template.gupshup.category === categoriaFiltro);
+    }
+
+    if (busquedaFiltro.trim() !== '') {
+      filtered = filtered.filter(template =>
+        template.gupshup.elementName.toLowerCase().includes(busquedaFiltro.toLowerCase())
+      );
+    }
+
+    setFilteredTemplates(filtered);
+  }, [tipoPlantillaFiltro, categoriaFiltro, busquedaFiltro, templates]);
+
+  // 🆕 Reiniciar a página 1 cuando cambien los filtros
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [tipoPlantillaFiltro, categoriaFiltro, busquedaFiltro]);
+
+  // 🆕 Cálculo de elementos actuales y total de páginas
+  const indexOfLastItem = currentPage * itemsPerPage;
+  const indexOfFirstItem = indexOfLastItem - itemsPerPage;
+  const currentItems = filteredTemplates.slice(indexOfFirstItem, indexOfLastItem);
+  const totalPages = Math.ceil(filteredTemplates.length / itemsPerPage);
 
   const handleFiltrarTipoPlantilla = (event) => {
     setTipoPlantillaFiltro(event.target.value);
@@ -170,7 +175,21 @@ const TemplateAproved = () => {
   };
 
   const handleEdit = (template) => {
-    navigate('/modify-template', { state: { template } });
+    if (["APPROVED", "REJECTED", "PAUSED"].includes(template.gupshup.status)) {
+      const routeMap = {
+        CAROUSEL: '/modify-template-carousel',
+        CATALOG: '/modify-template-catalogo',
+      };
+      navigate(routeMap[template.gupshup.templateType] || '/modify-template', { state: { template } });
+    } else {
+      Swal.fire({
+        title: 'La plantilla no puede ser editada.',
+        text: 'No se puede editar la plantilla porque su estado no es "APPROVED", "REJECTED" o "PAUSED".',
+        icon: 'error',
+        confirmButtonText: 'Cerrar',
+        confirmButtonColor: '#00c3ff'
+      });
+    }
   };
 
   const handleDeleteClick = (template) => {
@@ -296,6 +315,18 @@ const TemplateAproved = () => {
     DEFAULT: CardBase,
   };
 
+  // 🆕 Manejador de cambio de página
+  const handlePageChange = (event, value) => {
+    setCurrentPage(value);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const handleViewChange = (event, newView) => {
+    if (newView !== null) {
+      setViewMode(newView);
+    }
+  };
+
   return (
     <Box>
       <Box sx={{ display: 'flex' }}>
@@ -305,6 +336,28 @@ const TemplateAproved = () => {
             {/* Título */}<Typography variant="h4" gutterBottom>
               Catálogo de Plantillas
             </Typography>
+
+            <ToggleButtonGroup
+              value={viewMode}
+              exclusive
+              onChange={handleViewChange}
+              aria-label="vista"
+              size="small"
+              sx={{
+                marginLeft: { xs: 0, md: 'auto' },
+                '& .MuiToggleButton-root': {
+                  px: 2,
+                  py: 0.5
+                }
+              }}
+            >
+              <ToggleButton value="grid" aria-label="vista grid">
+                <ViewModuleIcon />
+              </ToggleButton>
+              <ToggleButton value="list" aria-label="vista lista">
+                <ViewListIcon />
+              </ToggleButton>
+            </ToggleButtonGroup>
 
             <FormControl variant="outlined" sx={{ marginLeft: 'auto', minWidth: 400 }}>
               <InputLabel htmlFor="input-with-icon-adornment">
@@ -359,57 +412,102 @@ const TemplateAproved = () => {
             </FormControl>
           </Box>
 
-          {/* Grid de tarjetas */}
+          {/* Contenido de plantillas */}
+          {loading ? (
+            <Box sx={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
+              gap: 3,
+              justifyItems: "center"
+            }}>
+              {Array.from({ length: 4 }).map((_, index) => <CardBaseSkeleton key={index} />)}
+            </Box>
+          ) : currentItems.length > 0 ? (
+            viewMode === 'grid' ? (
+              /* 👇 VISTA GRID */
+              <Box sx={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
+                gap: 3,
+                justifyItems: "center"
+              }}>
+                {currentItems.map((template) => {
+                  const CardComponent = CardComponents[template.gupshup.templateType] || CardComponents.DEFAULT;
+                  return (
+                    <motion.div
+                      key={template.gupshup.id || template.id}
+                      variants={cardVariants}
+                      whileHover={{ scale: 1.05, y: -10, transition: { duration: 0.2 } }}
+                      whileTap={{ scale: 0.98 }}
+                    >
+                      <CardComponent
+                        template={template}
+                        handleEdit={handleEdit}
+                        handleDeleteClick={handleDeleteClick}
+                        showReasonAlert={showReasonAlert}
+                        parseTemplateContent={parseTemplateContent}
+                        getStatusColor={getStatusColor}
+                        getStatusDotColor={getStatusDotColor}
+                        getStatusTextColor={getStatusTextColor}
+                      />
+                    </motion.div>
+                  );
+                })}
+              </Box>
+            ) : (
+              /* 👇 VISTA LISTA */
+              <ListBase
+                templates={currentItems}
+                handleEdit={handleEdit}
+                handleDeleteClick={handleDeleteClick}
+                showReasonAlert={showReasonAlert}
+                parseTemplateContent={parseTemplateContent}
+                getStatusColor={getStatusColor}
+                getStatusDotColor={getStatusDotColor}
+                getStatusTextColor={getStatusTextColor}
+              />
+            )
+          ) : (
+            /* Estado vacío para ambas vistas */
+            <Box sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              minHeight: 300,
+              textAlign: 'center',
+              p: 4
+            }}>
+              <Typography variant="h6" sx={{ color: 'text.secondary' }}>
+                No se encontraron plantillas con los filtros actuales.
+              </Typography>
+            </Box>
+          )}
 
-          <Box sx={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
-            gap: 3,
-            justifyItems: "center"
-          }}>
-            {loading ?
-              Array.from(new Array(4)).map((_, index) => (
-                <CardBaseSkeleton key={index} />
-              ))
-              :
-              filteredTemplates.map((template) => {
-                const CardComponent = CardComponents[template.templateType] || CardComponents.DEFAULT;
+          {/* Paginación */}
+          {totalPages > 1 && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 5, mb: 3 }}>
+              <Pagination
+                count={totalPages}
+                page={currentPage}
+                onChange={handlePageChange}
+                color="primary"
+                size="large"
+                shape="rounded"
+                siblingCount={1}
+                boundaryCount={1}
+              />
+            </Box>
+          )}
 
-                return (
-                  <motion.div
-                    key={template.id}
-                    variants={cardVariants}
-                    whileHover={{
-                      scale: 1.05,
-                      y: -10,
-                      transition: { duration: 0.2 }
-                    }}
-                    whileTap={{ scale: 0.98 }}
-                  >
-                    <CardComponent
-                      key={template.id}
-                      template={template}
-                      handleEdit={handleEdit}
-                      handleDeleteClick={handleDeleteClick}
-                      showReasonAlert={showReasonAlert}
-                      parseTemplateContent={parseTemplateContent}
-                      getStatusColor={getStatusColor}
-                      getStatusDotColor={getStatusDotColor}
-                      getStatusTextColor={getStatusTextColor}
-                    />
-                  </motion.div>
-                );
-              })}
-          </Box>
+          <DeleteModal
+            open={deleteModalOpen}
+            onClose={handleDeleteCancel}
+            onConfirm={handleDeleteConfirm}
+            template={selectedTemplate}
+          />
         </Box>
       </Box>
-      {/* Modal de Eliminación */}
-      <DeleteModal
-        open={deleteModalOpen}
-        onClose={handleDeleteCancel}
-        onConfirm={handleDeleteConfirm}
-        template={selectedTemplate}
-      />
     </Box>
   );
 };

--- a/src/pages/TemplateList.jsx
+++ b/src/pages/TemplateList.jsx
@@ -1,28 +1,17 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useParams, useLocation } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 import { jwtDecode } from 'jwt-decode';
 import { motion } from 'framer-motion';
 import Swal from 'sweetalert2'
 
-import LoginRequired from './LoginRequired';
 import { fetchMergedTemplates } from '../api/templatesServices';
 
-import { alpha, Card, CardContent, Typography, CardActions, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Fade, Button, ListItemIcon, ListItemText, Grid, Box, Menu, MenuItem, Stack, TextField, Paper, styled } from '@mui/material';
-import { CircularProgress } from '@mui/material';
+import { Card, CardContent, Typography, Fade, Button, ListItemIcon, ListItemText, Box, Menu, MenuItem, Paper } from '@mui/material';
 
 import AddIcon from '@mui/icons-material/Add';
 import FindInPageIcon from '@mui/icons-material/FindInPage';
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import ArrowForward from '@mui/icons-material/ArrowForward';
-import Link from '@mui/icons-material/Link';
-import Phone from '@mui/icons-material/Phone';
-import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
-import ErrorIcon from '@mui/icons-material/Error';
 import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
-import CategoryIcon from '@mui/icons-material/Category';
 import AutoAwesomeMosaicIcon from '@mui/icons-material/AutoAwesomeMosaic';
 import ViewCarouselIcon from '@mui/icons-material/ViewCarousel';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
@@ -30,7 +19,6 @@ import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import DeleteModal from '../components/DeleteModal';
 import { parseTemplateContent } from "../utils/parseTemplateContent";
 
-import TemplateCardSkeleton from '../utils/SkeletonTemplates';
 import CardBase from '../components/CardBase';
 import CardBaseCarousel from '../components/CardBaseCarousel';
 import CardBaseSkeleton from '../components/CardBaseSkeleton';
@@ -87,26 +75,29 @@ export default function BasicCard() {
 
   const [isSupportMode, setIsSupportMode] = useState(false);
 
-  const token = sessionStorage.getItem('authToken');
+  const { appId, authCode, appName, idUsuarioTalkMe, idNombreUsuarioTalkMe, empresaTalkMe, idBotRedes, idBot, urlTemplatesGS, urlWsFTP, } = useMemo(() => {
+    const token = sessionStorage.getItem('authToken');
+    if (!token) return {};
 
-  let appId, authCode, appName, idUsuarioTalkMe, idNombreUsuarioTalkMe, empresaTalkMe, idBotRedes, idBot, urlTemplatesGS, urlWsFTP;
-  if (token) {
     try {
       const decoded = jwtDecode(token);
-      appId = decoded.app_id;
-      authCode = decoded.auth_code;
-      appName = decoded.app_name;
-      idUsuarioTalkMe = decoded.id_usuario;
-      idNombreUsuarioTalkMe = decoded.nombre_usuario;
-      empresaTalkMe = decoded.empresa;
-      idBotRedes = decoded.id_bot_redes;
-      idBot = decoded.id_bot;
-      urlTemplatesGS = decoded.urlTemplatesGS;
-      urlWsFTP = decoded.urlWsFTP;
+      return {
+        appId: decoded.app_id,
+        authCode: decoded.auth_code,
+        appName: decoded.app_name,
+        idUsuarioTalkMe: decoded.id_usuario,
+        idNombreUsuarioTalkMe: decoded.nombre_usuario,
+        empresaTalkMe: decoded.empresa,
+        idBotRedes: decoded.id_bot_redes,
+        idBot: decoded.id_bot,
+        urlTemplatesGS: decoded.urlTemplatesGS,
+        urlWsFTP: decoded.urlWsFTP,
+      };
     } catch (error) {
       console.error('Error decodificando el token:', error);
+      return {};
     }
-  }
+  }, []);
 
   const obtenerTemplatesMerge = async () => {
     try {
@@ -118,30 +109,26 @@ export default function BasicCard() {
   };
 
   useEffect(() => {
-    if (appId && authCode && urlTemplatesGS) {
-      setLoading(true);
-      obtenerTemplatesMerge()
-        .then(data => {
-          setTemplates(data);
-          setLoading(false);
-        });
-    } else {
-      console.error('No se encontró appId o authCode en el token');
-    }
-  }, [appId, authCode]);
-  //
-  useEffect(() => {
-  const handleKeyPress = (e) => {
-    if (e.ctrlKey && e.shiftKey && e.key === 'S') {
-      e.preventDefault();
-      setIsSupportMode(prev => !prev);
-      console.log('Modo soporte:', !isSupportMode);
-    }
-  };
+    if (!appId || !authCode || !urlTemplatesGS) return;
+    setLoading(true);
+    obtenerTemplatesMerge().then(data => {
+      setTemplates(data);
+      setLoading(false);
+    });
+  }, [appId, authCode, urlTemplatesGS]);
 
-  window.addEventListener('keydown', handleKeyPress);
-  return () => window.removeEventListener('keydown', handleKeyPress);
-}, [isSupportMode]);
+  useEffect(() => {
+    const handleKeyPress = (e) => {
+      if (e.ctrlKey && e.shiftKey && e.key === 'S') {
+        e.preventDefault();
+        setIsSupportMode(prev => !prev);
+        console.log('Modo soporte:', !isSupportMode);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyPress);
+    return () => window.removeEventListener('keydown', handleKeyPress);
+  }, [isSupportMode]);
 
 
   const getStatusColor = (status) => {

--- a/src/pages/TemplateRejected.jsx
+++ b/src/pages/TemplateRejected.jsx
@@ -1,34 +1,24 @@
-import React, { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
-import { alpha, Box, Button, Card, CardActions, CardContent, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Fade, FormControl, FormLabel, Input, InputAdornment, ListItemIcon, ListItemText, InputLabel, Menu, MenuItem, OutlinedInput, Select, Stack, styled, TextField, Typography } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
-import Sidebar from '../components/Sidebar';
+import React, { useState, useEffect, useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { alpha, Box, FormControl, InputAdornment, InputLabel, Menu, MenuItem, OutlinedInput, Select, styled, ToggleButton, ToggleButtonGroup, Typography, Pagination } from '@mui/material';
 import { jwtDecode } from 'jwt-decode';
 import { motion } from 'framer-motion';
 import Swal from 'sweetalert2'
 
 // ICONOS
-import AddIcon from '@mui/icons-material/Add';
-import FindInPageIcon from '@mui/icons-material/FindInPage';
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import ArrowForward from '@mui/icons-material/ArrowForward';
-import Link from '@mui/icons-material/Link';
-import Phone from '@mui/icons-material/Phone';
-import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
-import ErrorIcon from '@mui/icons-material/Error';
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import ViewListIcon from '@mui/icons-material/ViewList';
 
 // MODAL PARA ELIMINAR
 import DeleteModal from '../components/DeleteModal';
 import { parseTemplateContent } from "../utils/parseTemplateContent";
+import { fetchMergedTemplates } from '../api/templatesServices';
 
-import TemplateCardSkeleton from '../utils/SkeletonTemplates';
 import CardBase from '../components/CardBase';
 import CardBaseCarousel from '../components/CardBaseCarousel';
 import CardBaseSkeleton from '../components/CardBaseSkeleton';
-import { fetchMergedTemplates } from '../api/templatesServices';
+import ListBase from '../components/ListBase';
 
 const TemplateAproved = () => {
   const { templateId } = useParams();
@@ -41,20 +31,28 @@ const TemplateAproved = () => {
   const [tipoPlantillaFiltro, setTipoPlantillaFiltro] = useState('ALL');
   const [categoriaFiltro, setCategoriaFiltro] = useState('ALL');
   const [busquedaFiltro, setBusquedaFiltro] = useState('');
+  const [viewMode, setViewMode] = useState('grid');
 
-  const token = sessionStorage.getItem('authToken');
+  // 🆕 Estados y constantes para paginación
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 12; // Puedes ajustar este valor (9, 12, 15, etc.)
 
-  let appId, authCode, urlTemplatesGS;
-  if (token) {
+  const navigate = useNavigate();
+
+  const { appId, authCode, urlTemplatesGS } = useMemo(() => {
+    const token = sessionStorage.getItem('authToken');
+    if (!token) return {};
     try {
       const decoded = jwtDecode(token);
-      appId = decoded.app_id;
-      authCode = decoded.auth_code;
-      urlTemplatesGS = decoded.urlTemplatesGS;
-    } catch (error) {
-      console.error('Error decodificando el token:', error);
+      return {
+        appId: decoded.app_id,
+        authCode: decoded.auth_code,
+        urlTemplatesGS: decoded.urlTemplatesGS,
+      };
+    } catch {
+      return {};
     }
-  }
+  }, [])
 
   const obtenerTemplatesMerge = async () => {
     try {
@@ -70,44 +68,51 @@ const TemplateAproved = () => {
   };
 
   useEffect(() => {
-    if (appId && authCode && urlTemplatesGS) {
-      setLoading(true);
-      obtenerTemplatesMerge()
-        .then(data => {
-          setTemplates(data);
-          setLoading(false);
-        });
-    } else {
-      console.error('No se encontró appId, authCode o urlTemplatesGS en el token');
-    }
+    if (!appId || !authCode || !urlTemplatesGS) return;
+    setLoading(true);
+    obtenerTemplatesMerge().then(data => {
+      setTemplates(data);
+      setLoading(false);
+    });
   }, [appId, authCode, urlTemplatesGS]);
 
   useEffect(() => {
-        let filtered = [...templates];
-    
-        if (tipoPlantillaFiltro !== 'ALL') {
-          if (tipoPlantillaFiltro === 'FLOW') {
-            filtered = filtered.filter(template => template.gupshup.buttonSupported === 'FLOW');
-          } else {
-            filtered = filtered.filter(template => 
-              template.gupshup.templateType === tipoPlantillaFiltro &&
-              template.gupshup.buttonSupported !== 'FLOW'
-            );
-          }
-        }
-    
-        if (categoriaFiltro && categoriaFiltro !== 'ALL') {
-          filtered = filtered.filter(template => template.gupshup.category === categoriaFiltro);
-        }
-    
-        if (busquedaFiltro.trim() !== '') {
-          filtered = filtered.filter(template =>
-            template.gupshup.elementName.toLowerCase().includes(busquedaFiltro.toLowerCase())
-          );
-        }
-    
-        setFilteredTemplates(filtered);
-      }, [tipoPlantillaFiltro, categoriaFiltro, busquedaFiltro, templates]);
+    let filtered = [...templates];
+
+    if (tipoPlantillaFiltro !== 'ALL') {
+      if (tipoPlantillaFiltro === 'FLOW') {
+        filtered = filtered.filter(template => template.gupshup.buttonSupported === 'FLOW');
+      } else {
+        filtered = filtered.filter(template =>
+          template.gupshup.templateType === tipoPlantillaFiltro &&
+          template.gupshup.buttonSupported !== 'FLOW'
+        );
+      }
+    }
+
+    if (categoriaFiltro && categoriaFiltro !== 'ALL') {
+      filtered = filtered.filter(template => template.gupshup.category === categoriaFiltro);
+    }
+
+    if (busquedaFiltro.trim() !== '') {
+      filtered = filtered.filter(template =>
+        template.gupshup.elementName.toLowerCase().includes(busquedaFiltro.toLowerCase())
+      );
+    }
+
+    setFilteredTemplates(filtered);
+  }, [tipoPlantillaFiltro, categoriaFiltro, busquedaFiltro, templates]);
+
+  // 🆕 Reiniciar a página 1 cuando cambien los filtros
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [tipoPlantillaFiltro, categoriaFiltro, busquedaFiltro]);
+
+  // 🆕 Cálculo de elementos actuales y total de páginas
+  const indexOfLastItem = currentPage * itemsPerPage;
+  const indexOfFirstItem = indexOfLastItem - itemsPerPage;
+  const currentItems = filteredTemplates.slice(indexOfFirstItem, indexOfLastItem);
+  const totalPages = Math.ceil(filteredTemplates.length / itemsPerPage);
 
   const handleFiltrarTipoPlantilla = (event) => {
     setTipoPlantillaFiltro(event.target.value);
@@ -168,8 +173,12 @@ const TemplateAproved = () => {
   };
 
   const handleEdit = (template) => {
-    if (template.gupshup.status === "APPROVED" || template.gupshup.status === "REJECTED" || template.gupshup.status === "PAUSED") {
-      navigate('/modify-template', { state: { template } });
+    if (["APPROVED", "REJECTED", "PAUSED"].includes(template.gupshup.status)) {
+      const routeMap = {
+        CAROUSEL: '/modify-template-carousel',
+        CATALOG: '/modify-template-catalogo',
+      };
+      navigate(routeMap[template.gupshup.templateType] || '/modify-template', { state: { template } });
     } else {
       Swal.fire({
         title: 'La plantilla no puede ser editada.',
@@ -304,6 +313,18 @@ const TemplateAproved = () => {
     DEFAULT: CardBase,
   };
 
+  // 🆕 Manejador de cambio de página
+  const handlePageChange = (event, value) => {
+    setCurrentPage(value);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const handleViewChange = (event, newView) => {
+    if (newView !== null) {
+      setViewMode(newView);
+    }
+  };
+
   return (
     <Box>
       <Box sx={{ display: 'flex' }}>
@@ -313,6 +334,28 @@ const TemplateAproved = () => {
             {/* Título */}<Typography variant="h4" gutterBottom>
               Catálogo de Plantillas
             </Typography>
+
+            <ToggleButtonGroup
+              value={viewMode}
+              exclusive
+              onChange={handleViewChange}
+              aria-label="vista"
+              size="small"
+              sx={{
+                marginLeft: { xs: 0, md: 'auto' },
+                '& .MuiToggleButton-root': {
+                  px: 2,
+                  py: 0.5
+                }
+              }}
+            >
+              <ToggleButton value="grid" aria-label="vista grid">
+                <ViewModuleIcon />
+              </ToggleButton>
+              <ToggleButton value="list" aria-label="vista lista">
+                <ViewListIcon />
+              </ToggleButton>
+            </ToggleButtonGroup>
 
             <FormControl variant="outlined" sx={{ marginLeft: 'auto', minWidth: 400 }}>
               <InputLabel htmlFor="input-with-icon-adornment">
@@ -367,59 +410,102 @@ const TemplateAproved = () => {
             </FormControl>
           </Box>
 
-          {/* Grid de tarjetas */}
-          <Box sx={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
-            gap: 3,
-            justifyItems: "center"
-          }}>
-            {loading ?
-              Array.from(new Array(4)).map((_, index) => (
-                <CardBaseSkeleton key={index} />
-              ))
-              :
-              filteredTemplates.map((template) => {
-                const CardComponent = CardComponents[template.gupshup.templateType] || CardComponents.DEFAULT;
+          {/* Contenido de plantillas */}
+          {loading ? (
+            <Box sx={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
+              gap: 3,
+              justifyItems: "center"
+            }}>
+              {Array.from({ length: 4 }).map((_, index) => <CardBaseSkeleton key={index} />)}
+            </Box>
+          ) : currentItems.length > 0 ? (
+            viewMode === 'grid' ? (
+              /* 👇 VISTA GRID */
+              <Box sx={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
+                gap: 3,
+                justifyItems: "center"
+              }}>
+                {currentItems.map((template) => {
+                  const CardComponent = CardComponents[template.gupshup.templateType] || CardComponents.DEFAULT;
+                  return (
+                    <motion.div
+                      key={template.gupshup.id || template.id}
+                      variants={cardVariants}
+                      whileHover={{ scale: 1.05, y: -10, transition: { duration: 0.2 } }}
+                      whileTap={{ scale: 0.98 }}
+                    >
+                      <CardComponent
+                        template={template}
+                        handleEdit={handleEdit}
+                        handleDeleteClick={handleDeleteClick}
+                        showReasonAlert={showReasonAlert}
+                        parseTemplateContent={parseTemplateContent}
+                        getStatusColor={getStatusColor}
+                        getStatusDotColor={getStatusDotColor}
+                        getStatusTextColor={getStatusTextColor}
+                      />
+                    </motion.div>
+                  );
+                })}
+              </Box>
+            ) : (
+              /* 👇 VISTA LISTA */
+              <ListBase
+                templates={currentItems}
+                handleEdit={handleEdit}
+                handleDeleteClick={handleDeleteClick}
+                showReasonAlert={showReasonAlert}
+                parseTemplateContent={parseTemplateContent}
+                getStatusColor={getStatusColor}
+                getStatusDotColor={getStatusDotColor}
+                getStatusTextColor={getStatusTextColor}
+              />
+            )
+          ) : (
+            /* Estado vacío para ambas vistas */
+            <Box sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              minHeight: 300,
+              textAlign: 'center',
+              p: 4
+            }}>
+              <Typography variant="h6" sx={{ color: 'text.secondary' }}>
+                No se encontraron plantillas con los filtros actuales.
+              </Typography>
+            </Box>
+          )}
 
-                return (
-                  <motion.div
-                    key={template.id}
-                    variants={cardVariants}
-                    whileHover={{
-                      scale: 1.05,
-                      y: -10,
-                      transition: { duration: 0.2 }
-                    }}
-                    whileTap={{ scale: 0.98 }}
-                  >
-                    <CardComponent
-                      key={template.id}
-                      template={template}
-                      handleEdit={handleEdit}
-                      handleDeleteClick={handleDeleteClick}
-                      showReasonAlert={showReasonAlert}
-                      parseTemplateContent={parseTemplateContent}
-                      getStatusColor={getStatusColor}
-                      getStatusDotColor={getStatusDotColor}
-                      getStatusTextColor={getStatusTextColor}
-                    />
-                  </motion.div>
-                );
-              })}
-          </Box>
+          {/* Paginación */}
+          {totalPages > 1 && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 5, mb: 3 }}>
+              <Pagination
+                count={totalPages}
+                page={currentPage}
+                onChange={handlePageChange}
+                color="primary"
+                size="large"
+                shape="rounded"
+                siblingCount={1}
+                boundaryCount={1}
+              />
+            </Box>
+          )}
 
-
+          <DeleteModal
+            open={deleteModalOpen}
+            onClose={handleDeleteCancel}
+            onConfirm={handleDeleteConfirm}
+            template={selectedTemplate}
+          />
         </Box>
       </Box>
-
-      {/* Modal de Eliminación */}
-      <DeleteModal
-        open={deleteModalOpen}
-        onClose={handleDeleteCancel}
-        onConfirm={handleDeleteConfirm}
-        template={selectedTemplate}
-      />
     </Box>
   );
 };

--- a/src/pages/TemplateSend.jsx
+++ b/src/pages/TemplateSend.jsx
@@ -1,33 +1,25 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
-import { alpha, Box, Button, Card, CardActions, CardContent, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Fade, FormControl, FormLabel, Input, InputAdornment, ListItemIcon, ListItemText, InputLabel, Menu, MenuItem, OutlinedInput, Select, Stack, styled, TextField, Typography } from '@mui/material';
+import { alpha, Box, FormControl, InputAdornment, InputLabel, Menu, MenuItem, OutlinedInput, Select, styled, ToggleButton, ToggleButtonGroup, Typography, Pagination } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
-import Sidebar from '../components/Sidebar';
 import { jwtDecode } from 'jwt-decode';
 import { motion } from 'framer-motion';
+import Swal from 'sweetalert2';
 
 // ICONOS
-import AddIcon from '@mui/icons-material/Add';
-import FindInPageIcon from '@mui/icons-material/FindInPage';
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import ArrowForward from '@mui/icons-material/ArrowForward';
-import Link from '@mui/icons-material/Link';
-import Phone from '@mui/icons-material/Phone';
-import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
-import ErrorIcon from '@mui/icons-material/Error';
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import ViewListIcon from '@mui/icons-material/ViewList';
 
 // MODAL PARA ELIMINAR
 import DeleteModal from '../components/DeleteModal';
 import { parseTemplateContent } from "../utils/parseTemplateContent";
+import { fetchMergedTemplates } from '../api/templatesServices';
+
 import CardBase from '../components/CardBase';
 import CardBaseCarousel from '../components/CardBaseCarousel';
 import CardBaseSkeleton from '../components/CardBaseSkeleton';
-
-import TemplateCardSkeleton from '../utils/SkeletonTemplates';
-import { fetchMergedTemplates } from '../api/templatesServices';
+import ListBase from '../components/ListBase';
 
 const TemplateAproved = () => {
   const { templateId } = useParams();
@@ -40,22 +32,28 @@ const TemplateAproved = () => {
   const [tipoPlantillaFiltro, setTipoPlantillaFiltro] = useState('ALL');
   const [categoriaFiltro, setCategoriaFiltro] = useState('ALL');
   const [busquedaFiltro, setBusquedaFiltro] = useState('');
+  const [viewMode, setViewMode] = useState('grid');
+
+  // 🆕 Estados y constantes para paginación
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 12; // Puedes ajustar este valor (9, 12, 15, etc.)
 
   const navigate = useNavigate();
 
-  const token = sessionStorage.getItem('authToken');
-
-  let appId, authCode, urlTemplatesGS;
-  if (token) {
+  const { appId, authCode, urlTemplatesGS } = useMemo(() => {
+    const token = sessionStorage.getItem('authToken');
+    if (!token) return {};
     try {
       const decoded = jwtDecode(token);
-      appId = decoded.app_id;
-      authCode = decoded.auth_code;
-      urlTemplatesGS = decoded.urlTemplatesGS;
-    } catch (error) {
-      console.error('Error decodificando el token:', error);
+      return {
+        appId: decoded.app_id,
+        authCode: decoded.auth_code,
+        urlTemplatesGS: decoded.urlTemplatesGS,
+      };
+    } catch {
+      return {};
     }
-  }
+  }, [])
 
   const obtenerTemplatesMerge = async () => {
     try {
@@ -71,44 +69,51 @@ const TemplateAproved = () => {
   };
 
   useEffect(() => {
-    if (appId && authCode && urlTemplatesGS) {
-      setLoading(true);
-      obtenerTemplatesMerge()
-        .then(data => {
-          setTemplates(data);
-          setLoading(false);
-        });
-    } else {
-      console.error('No se encontró appId, authCode o urlTemplatesGS en el token');
-    }
+    if (!appId || !authCode || !urlTemplatesGS) return;
+    setLoading(true);
+    obtenerTemplatesMerge().then(data => {
+      setTemplates(data);
+      setLoading(false);
+    });
   }, [appId, authCode, urlTemplatesGS]);
 
   useEffect(() => {
-        let filtered = [...templates];
-    
-        if (tipoPlantillaFiltro !== 'ALL') {
-          if (tipoPlantillaFiltro === 'FLOW') {
-            filtered = filtered.filter(template => template.gupshup.buttonSupported === 'FLOW');
-          } else {
-            filtered = filtered.filter(template => 
-              template.gupshup.templateType === tipoPlantillaFiltro &&
-              template.gupshup.buttonSupported !== 'FLOW'
-            );
-          }
-        }
-    
-        if (categoriaFiltro && categoriaFiltro !== 'ALL') {
-          filtered = filtered.filter(template => template.gupshup.category === categoriaFiltro);
-        }
-    
-        if (busquedaFiltro.trim() !== '') {
-          filtered = filtered.filter(template =>
-            template.gupshup.elementName.toLowerCase().includes(busquedaFiltro.toLowerCase())
-          );
-        }
-    
-        setFilteredTemplates(filtered);
-      }, [tipoPlantillaFiltro, categoriaFiltro, busquedaFiltro, templates]);
+    let filtered = [...templates];
+
+    if (tipoPlantillaFiltro !== 'ALL') {
+      if (tipoPlantillaFiltro === 'FLOW') {
+        filtered = filtered.filter(template => template.gupshup.buttonSupported === 'FLOW');
+      } else {
+        filtered = filtered.filter(template =>
+          template.gupshup.templateType === tipoPlantillaFiltro &&
+          template.gupshup.buttonSupported !== 'FLOW'
+        );
+      }
+    }
+
+    if (categoriaFiltro && categoriaFiltro !== 'ALL') {
+      filtered = filtered.filter(template => template.gupshup.category === categoriaFiltro);
+    }
+
+    if (busquedaFiltro.trim() !== '') {
+      filtered = filtered.filter(template =>
+        template.gupshup.elementName.toLowerCase().includes(busquedaFiltro.toLowerCase())
+      );
+    }
+
+    setFilteredTemplates(filtered);
+  }, [tipoPlantillaFiltro, categoriaFiltro, busquedaFiltro, templates]);
+
+  // 🆕 Reiniciar a página 1 cuando cambien los filtros
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [tipoPlantillaFiltro, categoriaFiltro, busquedaFiltro]);
+
+  // 🆕 Cálculo de elementos actuales y total de páginas
+  const indexOfLastItem = currentPage * itemsPerPage;
+  const indexOfFirstItem = indexOfLastItem - itemsPerPage;
+  const currentItems = filteredTemplates.slice(indexOfFirstItem, indexOfLastItem);
+  const totalPages = Math.ceil(filteredTemplates.length / itemsPerPage);
 
   const handleFiltrarTipoPlantilla = (event) => {
     setTipoPlantillaFiltro(event.target.value);
@@ -169,23 +174,12 @@ const TemplateAproved = () => {
   };
 
   const handleEdit = (template) => {
-    if (template.gupshup.status === "APPROVED" || template.gupshup.status === "REJECTED" || template.gupshup.status === "PAUSED") {
-      switch (template.gupshup.templateType) {
-        case 'CAROUSEL':
-          navigate('/modify-template-carousel', { state: { template } });
-          break;
-        case 'CATALOGO':
-          navigate('/modify-template-catalogo', { state: { template } });
-          break;
-        case 'TEXT':
-        case 'IMAGE':
-        case 'DOCUMENT':
-        case 'VIDEO':
-          navigate('/modify-template', { state: { template } });
-          break;
-        default:
-          navigate('/modify-template', { state: { template } });
-      }
+    if (["APPROVED", "REJECTED", "PAUSED"].includes(template.gupshup.status)) {
+      const routeMap = {
+        CAROUSEL: '/modify-template-carousel',
+        CATALOG: '/modify-template-catalogo',
+      };
+      navigate(routeMap[template.gupshup.templateType] || '/modify-template', { state: { template } });
     } else {
       Swal.fire({
         title: 'La plantilla no puede ser editada.',
@@ -320,6 +314,18 @@ const TemplateAproved = () => {
     DEFAULT: CardBase,
   };
 
+  // 🆕 Manejador de cambio de página
+  const handlePageChange = (event, value) => {
+    setCurrentPage(value);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const handleViewChange = (event, newView) => {
+    if (newView !== null) {
+      setViewMode(newView);
+    }
+  };
+
   return (
     <Box>
       <Box sx={{ display: 'flex' }}>
@@ -329,6 +335,28 @@ const TemplateAproved = () => {
             {/* Título */}<Typography variant="h4" gutterBottom>
               Catálogo de Plantillas
             </Typography>
+
+            <ToggleButtonGroup
+              value={viewMode}
+              exclusive
+              onChange={handleViewChange}
+              aria-label="vista"
+              size="small"
+              sx={{
+                marginLeft: { xs: 0, md: 'auto' },
+                '& .MuiToggleButton-root': {
+                  px: 2,
+                  py: 0.5
+                }
+              }}
+            >
+              <ToggleButton value="grid" aria-label="vista grid">
+                <ViewModuleIcon />
+              </ToggleButton>
+              <ToggleButton value="list" aria-label="vista lista">
+                <ViewListIcon />
+              </ToggleButton>
+            </ToggleButtonGroup>
 
             <FormControl variant="outlined" sx={{ marginLeft: 'auto', minWidth: 400 }}>
               <InputLabel htmlFor="input-with-icon-adornment">
@@ -382,55 +410,103 @@ const TemplateAproved = () => {
               </Select>
             </FormControl>
           </Box>
-          {/* Grid de tarjetas */}
-          <Box sx={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
-            gap: 3,
-            justifyItems: "center"
-          }}>
-            {loading ?
-              Array.from(new Array(4)).map((_, index) => (
-                <CardBaseSkeleton key={index} />
-              ))
-              :
-              filteredTemplates.map((template) => {
-                const CardComponent = CardComponents[template.templateType] || CardComponents.DEFAULT;
-                return (
-                  <motion.div
-                    key={template.id}
-                    variants={cardVariants}
-                    whileHover={{
-                      scale: 1.05,
-                      y: -10,
-                      transition: { duration: 0.2 }
-                    }}
-                    whileTap={{ scale: 0.98 }}
-                  >
-                    <CardComponent
-                      key={template.id}
-                      template={template}
-                      handleEdit={handleEdit}
-                      handleDeleteClick={handleDeleteClick}
-                      showReasonAlert={showReasonAlert}
-                      parseTemplateContent={parseTemplateContent}
-                      getStatusColor={getStatusColor}
-                      getStatusDotColor={getStatusDotColor}
-                      getStatusTextColor={getStatusTextColor}
-                    />
-                  </motion.div>
-                );
-              })}
-          </Box>
+
+          {/* Contenido de plantillas */}
+          {loading ? (
+            <Box sx={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
+              gap: 3,
+              justifyItems: "center"
+            }}>
+              {Array.from({ length: 4 }).map((_, index) => <CardBaseSkeleton key={index} />)}
+            </Box>
+          ) : currentItems.length > 0 ? (
+            viewMode === 'grid' ? (
+              /* 👇 VISTA GRID */
+              <Box sx={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
+                gap: 3,
+                justifyItems: "center"
+              }}>
+                {currentItems.map((template) => {
+                  const CardComponent = CardComponents[template.gupshup.templateType] || CardComponents.DEFAULT;
+                  return (
+                    <motion.div
+                      key={template.gupshup.id || template.id}
+                      variants={cardVariants}
+                      whileHover={{ scale: 1.05, y: -10, transition: { duration: 0.2 } }}
+                      whileTap={{ scale: 0.98 }}
+                    >
+                      <CardComponent
+                        template={template}
+                        handleEdit={handleEdit}
+                        handleDeleteClick={handleDeleteClick}
+                        showReasonAlert={showReasonAlert}
+                        parseTemplateContent={parseTemplateContent}
+                        getStatusColor={getStatusColor}
+                        getStatusDotColor={getStatusDotColor}
+                        getStatusTextColor={getStatusTextColor}
+                      />
+                    </motion.div>
+                  );
+                })}
+              </Box>
+            ) : (
+              /* 👇 VISTA LISTA */
+              <ListBase
+                templates={currentItems}
+                handleEdit={handleEdit}
+                handleDeleteClick={handleDeleteClick}
+                showReasonAlert={showReasonAlert}
+                parseTemplateContent={parseTemplateContent}
+                getStatusColor={getStatusColor}
+                getStatusDotColor={getStatusDotColor}
+                getStatusTextColor={getStatusTextColor}
+              />
+            )
+          ) : (
+            /* Estado vacío para ambas vistas */
+            <Box sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              minHeight: 300,
+              textAlign: 'center',
+              p: 4
+            }}>
+              <Typography variant="h6" sx={{ color: 'text.secondary' }}>
+                No se encontraron plantillas con los filtros actuales.
+              </Typography>
+            </Box>
+          )}
+
+          {/* Paginación */}
+          {totalPages > 1 && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 5, mb: 3 }}>
+              <Pagination
+                count={totalPages}
+                page={currentPage}
+                onChange={handlePageChange}
+                color="primary"
+                size="large"
+                shape="rounded"
+                siblingCount={1}
+                boundaryCount={1}
+              />
+            </Box>
+          )}
+
+          <DeleteModal
+            open={deleteModalOpen}
+            onClose={handleDeleteCancel}
+            onConfirm={handleDeleteConfirm}
+            template={selectedTemplate}
+          />
         </Box>
       </Box>
-      {/* Modal de Eliminación */}
-      <DeleteModal
-        open={deleteModalOpen}
-        onClose={handleDeleteCancel}
-        onConfirm={handleDeleteConfirm}
-        template={selectedTemplate}
-      />
     </Box>
   );
 };

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,171 +1,56 @@
-import React, { Suspense } from 'react';
+// routes/index.jsx (o AppRoutes.jsx)
+import React, { lazy } from 'react';
 import { Routes, Route } from 'react-router-dom';
-import TemplateList from './pages/TemplateList';
-import CreateTemplatePage from './pages/CreateTemplatePage';
-import CreateTemplateCatalog from './pages/CreateTemplateCatalog';
-import CreateTemplateCarousel from './pages/CreateTemplateCarousel';
-import CreateTemplateFlow from './pages/CreateTemplateFlow';
-import EditTemplatePage from './pages/EditTemplatePage';
-import TemplateAll from './pages/TemplateAll';
-import TemplateAproved from './pages/TemplateAproved';
-import TemplateRejected from './pages/TemplateRejected';
-import TemplateFailed from './pages/TemplateFailed';
-import TemplateSend from './pages/TemplateSend';
-import ModifyTemplatePage from './pages/ModifyTemplatePage';
-import ModifyTemplateCarouselPage from './pages/ModifyTemplateCarouselPage';
-import ModifyTemplateCatalogPage from './pages/ModifyTemplateCatalogPage';
-import ModifyTemplateFlowPage from './pages/ModifyTemplateFlowPage';
-import Sidebar from './components/Sidebar';
-import ProtectedRoute from './utils/ProtectedRoute';
-import LoginRequired from './pages/LoginRequired';
-import SessionClose from './pages/SessionClose';
-import LoadingSpinner from './utils/LoadingSpinner';
+import SidebarLayout from '../src/components/SidebarLayout';
+import ProtectedRoute from '../src/utils/ProtectedRoute';
+import LoginRequired from '../src/pages/LoginRequired';
+import SessionClose from '../src/pages/SessionClose';
+
+const TemplateList = lazy(() => import('../src/pages/TemplateList'));
+const CreateTemplatePage = lazy(() => import('../src/pages/CreateTemplatePage'));
+const CreateTemplateCatalog = lazy(() => import('../src/pages/CreateTemplateCatalog'));
+const CreateTemplateCarousel = lazy(() => import('../src/pages/CreateTemplateCarousel'));
+const CreateTemplateFlow = lazy(() => import('../src/pages/CreateTemplateFlow'));
+const EditTemplatePage = lazy(() => import('../src/pages/EditTemplatePage'));
+const TemplateAll = lazy(() => import('../src/pages/TemplateAll'));
+const TemplateAproved = lazy(() => import('../src/pages/TemplateAproved'));
+const TemplateRejected = lazy(() => import('../src/pages/TemplateRejected'));
+const TemplateFailed = lazy(() => import('../src/pages/TemplateFailed'));
+const TemplateSend = lazy(() => import('../src/pages/TemplateSend'));
+const ModifyTemplatePage = lazy(() => import('../src/pages/ModifyTemplatePage'));
+const ModifyTemplateCarouselPage = lazy(() => import('../src/pages/ModifyTemplateCarouselPage'));
+const ModifyTemplateCatalogPage = lazy(() => import('../src/pages/ModifyTemplateCatalogPage'));
+const ModifyTemplateFlowPage = lazy(() => import('../src/pages/ModifyTemplateFlowPage'));
 
 const AppRoutes = () => {
   return (
-    <>
-      
-      <Suspense fallback={<LoadingSpinner />}>
+    <Routes>
+      {/* Rutas públicas */}
+      <Route path="/login-required" element={<LoginRequired />} />
+      <Route path="/session-closed" element={<SessionClose />} />
 
-      <Routes>
-        {/* Ruta pública para la página de error */}
-        <Route path="/login-required" element={<LoginRequired />} />
-        <Route path="/session-closed" element={<SessionClose />} />
-
-        {/* Rutas protegidas */}
-        <Route element={<Sidebar />}>
-          <Route
-            index
-            element={
-              <ProtectedRoute>
-                <TemplateList />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/dashboard"
-            element={
-              <ProtectedRoute>
-                <TemplateList />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/CreateTemplatePage/CreateTemplatePage"
-            element={
-              <ProtectedRoute>
-                <CreateTemplatePage />
-              </ProtectedRoute>
-            }
-          />
-            <Route
-              path="/CreateTemplatePage/CreateTemplateCatalog"
-              element={
-                <ProtectedRoute>
-                  <CreateTemplateCatalog />
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/CreateTemplatePage/CreateTemplateCarousel"
-              element={
-                <ProtectedRoute>
-                  <CreateTemplateCarousel />
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/CreateTemplatePage/CreateTemplateFlow"
-              element={
-                <ProtectedRoute>
-                  <CreateTemplateFlow />
-                </ProtectedRoute>
-              }
-            />
-          <Route
-            path="/edit-template"
-            element={
-              <ProtectedRoute>
-                <EditTemplatePage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/modify-template"
-            element={
-              <ProtectedRoute>
-                <ModifyTemplatePage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/modify-template-carousel"
-            element={
-              <ProtectedRoute>
-                <ModifyTemplateCarouselPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/modify-template-catalogo"
-            element={
-              <ProtectedRoute>
-                <ModifyTemplateCatalogPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/modify-template-flow"
-            element={
-              <ProtectedRoute>
-                <ModifyTemplateFlowPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/plantillas/todas"
-            element={
-              <ProtectedRoute>
-                <TemplateAll />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/plantillas/aprobadas"
-            element={
-              <ProtectedRoute>
-                <TemplateAproved />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/plantillas/rechazadas"
-            element={
-              <ProtectedRoute>
-                <TemplateRejected />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/plantillas/fallidas"
-            element={
-              <ProtectedRoute>
-                <TemplateFailed />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/plantillas/enviadas"
-            element={
-              <ProtectedRoute>
-                <TemplateSend />
-              </ProtectedRoute>
-            }
-          />
+      {/* Rutas protegidas con layout */}
+      <Route element={<ProtectedRoute />}>
+        <Route element={<SidebarLayout />}>
+          <Route index element={<TemplateList />} />
+          <Route path="/dashboard" element={<TemplateList />} />
+          <Route path="/CreateTemplatePage/CreateTemplatePage" element={<CreateTemplatePage />} />
+          <Route path="/CreateTemplatePage/CreateTemplateCatalog" element={<CreateTemplateCatalog />} />
+          <Route path="/CreateTemplatePage/CreateTemplateCarousel" element={<CreateTemplateCarousel />} />
+          <Route path="/CreateTemplatePage/CreateTemplateFlow" element={<CreateTemplateFlow />} />
+          <Route path="/edit-template" element={<EditTemplatePage />} />
+          <Route path="/modify-template" element={<ModifyTemplatePage />} />
+          <Route path="/modify-template-carousel" element={<ModifyTemplateCarouselPage />} />
+          <Route path="/modify-template-catalogo" element={<ModifyTemplateCatalogPage />} />
+          <Route path="/modify-template-flow" element={<ModifyTemplateFlowPage />} />
+          <Route path="/plantillas/todas" element={<TemplateAll />} />
+          <Route path="/plantillas/aprobadas" element={<TemplateAproved />} />
+          <Route path="/plantillas/rechazadas" element={<TemplateRejected />} />
+          <Route path="/plantillas/fallidas" element={<TemplateFailed />} />
+          <Route path="/plantillas/enviadas" element={<TemplateSend />} />
         </Route>
-      </Routes>
-      </Suspense>
-    </>
+      </Route>
+    </Routes>
   );
 };
 

--- a/src/utils/ProtectedRoute.jsx
+++ b/src/utils/ProtectedRoute.jsx
@@ -1,35 +1,27 @@
 import React from 'react';
 import { jwtDecode } from 'jwt-decode';
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
-const ProtectedRoute = ({ children }) => {
+const ProtectedRoute = () => {
   const location = useLocation();
 
   const isLocalDevelopment = process.env.NODE_ENV === 'development' &&
     (window.location.hostname === 'localhost' ||
       window.location.hostname === '127.0.0.1');
 
-  if (isLocalDevelopment) {
-    return children;
-  }
+  if (isLocalDevelopment) return <Outlet />;
 
   const token = sessionStorage.getItem('authToken');
-
-  if (!token) {
-    return <Navigate to="/login-required" state={{ from: location }} replace />;
-  }
+  if (!token) return <Navigate to="/login-required" state={{ from: location }} replace />;
 
   try {
     const decoded = jwtDecode(token);
-    const currentTime = Date.now() / 1000;
-
-    if (decoded.exp < currentTime) {
+    if (decoded.exp < Date.now() / 1000) {
       sessionStorage.removeItem('authToken');
       return <Navigate to="/login-required" state={{ from: location }} replace />;
     }
-
-    return children;
-  } catch (error) {
+    return <Outlet />;
+  } catch {
     sessionStorage.removeItem('authToken');
     return <Navigate to="/login-required" state={{ from: location }} replace />;
   }


### PR DESCRIPTION
Fix: re-render de menus
Feat: paginacion de templates
Feat: listado de plantillas combinado a las tarjetas grid


En la versión anterior al presionar cualquier parte del menu se re-renderizaba y mostraba en blanco la pantalla
<img width="708" height="644" alt="imagen" src="https://github.com/user-attachments/assets/a61210ab-c8d5-4a3e-bf49-fdc82eb475e2" />
Ahora al usar las opciones el render es correcto y el menú tiene un estilo de selección mejor
<img width="712" height="571" alt="imagen" src="https://github.com/user-attachments/assets/52cc0d56-33a3-4ec7-a9cf-6cc636221a0b" />

Se agrego una segunda opción de visualización en el listado y páginacion para evitar un scroll demasiado extenso al obtener muchas plantillas
<img width="1051" height="496" alt="imagen" src="https://github.com/user-attachments/assets/2dfcae52-6b8d-4c1e-96d7-18358ab9c2ed" />

<img width="617" height="186" alt="imagen" src="https://github.com/user-attachments/assets/8e632bb0-33cd-4379-b5e6-76cb3ef3a31c" />
